### PR TITLE
Add user-facing LoRA/PEFT adapter support doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Generation:
 - [0.0.10 release notes](release-notes/0.0.10.md) Detailed notes for the Qwen3, JQ4, tensor-parallel, GPU, nanocode, and benchmarking release
 - [Qwen3 support](core/qwen3_support.md) Documents Qwen3 integration status, tests, and limitations
 - [Gemma4 support](core/gemma4_support.md) High-level status, usage, and notes for Gemma 4 support in Deliverance
+- [LoRA/PEFT adapter support](core/lora_support.md) Explains what LoRA adapters are, why Deliverance is adding support, and current implementation status
 - [Grace tokenizer module](grace/README.md) Explains Deliverance's fuller-featured tokenizer path and how to use it
 - [Tokenizer showdown](grace/tokenizer_showdown.md) Compares Grace Java tokenization against Hugging Face's Rust-backed tokenizers
 - [Inference engine flow](core/inference_flow.md) Explains the transformations and flows http/prompt/jinja/ etc.

--- a/core/lora_support.md
+++ b/core/lora_support.md
@@ -1,0 +1,84 @@
+# LoRA / PEFT Adapter Support
+
+Deliverance is adding support for LoRA (Low-Rank Adaptation) adapters in the standard
+HuggingFace PEFT format. The goal is to let a single resident base model take on specialized
+behavior — a particular skill, style, or persona — by loading a small adapter file on top of
+it, instead of downloading and holding a second full multi-gigabyte checkpoint per variant.
+This page is written for readers who know Deliverance but have never worked with LoRA/PEFT
+adapters before.
+
+## What Is A LoRA Adapter?
+
+A LoRA adapter is not a second model. It is a small set of extra weights, trained separately
+from the base model, that nudge the base model's behavior in a particular direction when
+combined with it at inference time.
+
+Full fine-tuning produces a new copy of every weight in the model — for a multi-billion
+parameter model, that is another multi-gigabyte file per variant. LoRA instead trains a pair of
+much smaller matrices per targeted layer (a low-rank decomposition, hence the name) that
+approximate the *change* fine-tuning would have made, without touching the base weights
+directly. The practical result is what matters here, not the linear algebra: an adapter file is
+typically single-digit to a few tens of megabytes, it is swappable independently of the base
+model, and it does not duplicate the base model's weights.
+
+## Why This Matters
+
+- **Cheap specialization**: get a specialized assistant, tone, or skill on top of one base
+  model without paying the storage and load-time cost of a full model per variant.
+- **Fast iteration**: adapters are small enough to train, share, and swap far more quickly than
+  retraining or redistributing a full checkpoint.
+- **One resident base model, many behaviors**: the eventual goal (Phase 2 below) is to keep one
+  base model loaded and switch which adapter is applied per request, rather than loading a
+  different full model for each behavior.
+- **Standard, portable format**: adapters trained anywhere in the HuggingFace PEFT ecosystem
+  should work with Deliverance's support, without a Deliverance-specific training or export
+  step.
+
+## Current Status
+
+**This is not usable for inference today.** As of this doc, only adapter *parsing* has landed
+([#153](https://github.com/edwardcapriolo/deliverance/pull/153)): Deliverance can fetch a PEFT
+adapter repository, parse its `adapter_config.json`, and read the low-rank weight deltas out of
+its `adapter_model.safetensors` file. Nothing in model loading or generation consumes an adapter
+yet — there is no way to actually apply one to a running model. Treat the feature as
+in-progress, not available.
+
+## Roadmap
+
+1. **Adapter parsing** — done. Deliverance can read an adapter's config and weights into memory
+   and validate them against the adapter's own declared shape.
+2. **Merge-at-load (Phase 1)** — planned next. The adapter's weights are merged into a copy of
+   the base model's weights when the model is loaded, producing a single adapted model. This is
+   the simpler of the two integration modes and proves the format and math end-to-end before
+   tackling anything more dynamic.
+3. **Runtime hot-swap (Phase 2)** — planned after Phase 1. Adapters are loaded once and can be
+   switched per request without reloading or duplicating the base model, enabling the "one base
+   model, many behaviors" use case described above.
+
+## Terminology
+
+- **Adapter**: the small set of trained weights (plus a config file) that make up a LoRA
+  fine-tune, distributed separately from the base model.
+- **Rank (`r`)**: the size of the low-rank decomposition used by the adapter. Lower rank means
+  fewer parameters and a smaller adapter file; higher rank can capture more complex changes to
+  behavior.
+- **Alpha**: a scaling factor applied to the adapter's contribution. Combined with rank, it
+  determines how strongly the adapter's weights influence the base model's output.
+- **Target modules**: the specific layers/weight matrices within the base model that the
+  adapter modifies. An adapter does not necessarily touch every layer.
+- **Base model**: the original, unmodified model an adapter is trained against and applied on
+  top of.
+- **Merge**: combining an adapter's weights into a copy of the base model's weights, producing
+  a single adapted set of weights (Phase 1).
+- **Hot-swap**: applying (or switching) an adapter against a resident base model at inference
+  time, without merging into a persistent copy of the weights (Phase 2).
+- **PEFT**: HuggingFace's "Parameter-Efficient Fine-Tuning" library and adapter format;
+  Deliverance's adapter support targets PEFT's standard output format.
+
+## Where This Comes From
+
+Deliverance's adapter support targets the standard HuggingFace PEFT adapter layout: an
+`adapter_config.json` file alongside an `adapter_model.safetensors` file. For the deeper
+mechanics of LoRA and PEFT — the math behind the low-rank decomposition, how adapters are
+trained — see [HuggingFace's PEFT documentation](https://huggingface.co/docs/peft/index),
+which this doc deliberately does not try to reproduce.


### PR DESCRIPTION
## Summary

Per feedback on #153: "Before the next phase focus on a user facing doc so people not familiar with lora understand the user facing goals of the support."

Adds `core/lora_support.md`, a conceptual orientation doc (not API reference — there's no public API yet) aimed at a Deliverance contributor/user who has never worked with LoRA/PEFT adapters. Covers:

- What a LoRA adapter is and how it differs from a full fine-tuned checkpoint (plain-language, no linear algebra required)
- Why Deliverance is adding support (cheap specialization on top of one resident base model)
- Current status, stated explicitly: adapter parsing (#153) is merged, but nothing is wired into model loading yet — **not usable for inference today**
- The planned roadmap: merge-at-load (Phase 1) then runtime hot-swap (Phase 2), in plain terms
- A short terminology glossary (adapter, rank/`r`, alpha, target modules, merge vs. hot-swap, base model, PEFT)
- A pointer to HuggingFace's PEFT docs for readers who want the deeper mechanics

Also adds the doc to `README.md`'s "Learning and Developer docs" list, alongside the other `core/*.md` feature docs.

Doc-only PR, no code changes — deliberately kept separate from the Phase 1 (`MergingWeightLoader`) work that follows it.

## Two questions for you

1. Is the intended audience really "Deliverance users/contributors unfamiliar with LoRA," or more of an external-facing blurb for people evaluating Deliverance who don't know it exists yet? That changes how much Deliverance-internal framing (`WeightLoader`, builder API) is appropriate even at a high level — I kept it light on purpose, but can adjust.
2. Does the doc land at the right technical level, or is it too basic/too technical for the audience you had in mind?

## Test plan

- [x] Doc-only change, no tests to run
- [x] Terminology (rank/`r`, alpha, target_modules) cross-checked against the actual `LoraAdapterConfig` fields parsed in #153, not a generic recollection of PEFT
- [x] No speculative/unimplemented API presented as working
- [x] Current status stated explicitly rather than implying a usable feature