### PR TITLE
Add MergingWeightLoader for LoRA merge-at-load support (PR #3)

### DIFF
--- a/benchmarks/run-lora-adapter-benchmark.sh
+++ b/benchmarks/run-lora-adapter-benchmark.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ -n "${JAVA_HOME:-}" ]; then
+  PATH="$JAVA_HOME/bin:$PATH"
+  JAVA_BIN="$JAVA_HOME/bin/java"
+else
+  JAVA_BIN="java"
+fi
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+ROOT_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+OS_NAME=$(uname -s)
+OS_ARCH=$(uname -m)
+case "$OS_NAME:$OS_ARCH" in
+  Darwin:arm64|Darwin:aarch64) NATIVE_CLASSIFIER=osx-aarch_64 ;;
+  Darwin:x86_64) NATIVE_CLASSIFIER=osx-x86_64 ;;
+  Linux:aarch64|Linux:arm64) NATIVE_CLASSIFIER=linux-aarch_64 ;;
+  Linux:x86_64|Linux:amd64) NATIVE_CLASSIFIER=linux-x86_64 ;;
+  *) printf '%s\n' "Unsupported native platform: $OS_NAME $OS_ARCH" >&2; exit 1 ;;
+esac
+
+NATIVE_CLASSIFIER=${DELIVERANCE_NATIVE_CLASSIFIER:-$NATIVE_CLASSIFIER}
+NATIVE_LIB_DIR="$ROOT_DIR/native/target/native-lib-only/$NATIVE_CLASSIFIER"
+OUTPUT=${DELIVERANCE_LORA_BENCHMARK_OUTPUT:-"$ROOT_DIR/core/target/lora-adapter-benchmark.csv"}
+JSONL_OUTPUT=${DELIVERANCE_LORA_BENCHMARK_JSONL_OUTPUT:-"$ROOT_DIR/core/target/lora-adapter-benchmark.jsonl"}
+BENCHMARK_ARGS=${DELIVERANCE_BENCHMARK_ARGS:-"--owner unsloth --model Llama-3.2-1B-Instruct --adapter-owner bunnycore --adapter-model Llama-3.2-1b-chatml-lora_model --output $OUTPUT --jsonl-output $JSONL_OUTPUT --max-tokens 128 --profile-stages"}
+
+cd "$ROOT_DIR"
+
+mvn -q -pl core \
+  -Dexec.classpathScope=test \
+  -Dexec.executable="$JAVA_BIN" \
+  -Dexec.args="-Djava.library.path=$NATIVE_LIB_DIR --add-modules jdk.incubator.vector,jdk.httpserver,java.net.http --add-opens java.base/java.nio=ALL-UNNAMED --enable-native-access=ALL-UNNAMED -cp %classpath io.teknek.deliverance.benchmark.LoraAdapterBenchmark $BENCHMARK_ARGS" \
+  org.codehaus.mojo:exec-maven-plugin:3.5.0:exec

--- a/core/benchmarking.md
+++ b/core/benchmarking.md
@@ -45,6 +45,43 @@ This is a qualitative smoke benchmark, not a throughput benchmark. It runs bound
 
 Use it after Qwen model/runtime changes to catch obvious regressions without hand-checking every prompt. Default output is `core/target/thinking-smoke-qwen3-4b-jq4.jsonl`.
 
+### LoRA Adapter Benchmark
+
+```sh
+./benchmarks/run-lora-adapter-benchmark.sh
+```
+
+Compares an un-adapted base model against the same base model with a LoRA/PEFT adapter merged in
+at load time (`AutoModelForCausaLm.Builder.withLoraAdapter(...)`, backed by
+`MergingWeightLoader`). Default pairing is `unsloth/Llama-3.2-1B-Instruct` (dense HF format,
+required by the merge-at-load dtype guard) with adapter `bunnycore/Llama-3.2-1b-chatml-lora_model`.
+Both models run the same small fixed prompt suite (chat/knowledge/math/writing/coding/reasoning,
+6 cases) with the same max-tokens/temperature held fixed.
+
+Outputs:
+
+- CSV at `core/target/lora-adapter-benchmark.csv` -- the same column set as
+  [Inference Benchmark](InferenceBenchmark.md)'s documented columns, with a `variant` column
+  (`base` or `lora-adapted`) in place of `engine`/`turn`, so filtering or diffing the CSV by
+  `case_id` directly surfaces the adapter's timing overhead.
+- JSONL transcript at `core/target/lora-adapter-benchmark.jsonl` -- one row per case per variant
+  with `prompt`, `response`, `generated_tokens`, `time_ms`, and `time_to_first_token_ms`, giving a
+  readable example of how each prompt is handled with and without the adapter.
+
+Pass `--profile-stages` (on by default in the script) to also print `[profile]` timing summaries
+per case/variant, using the same `InferenceProfiler` instrumentation the other benchmarks use.
+
+Override the model/adapter pairing with `DELIVERANCE_BENCHMARK_ARGS`:
+
+```sh
+DELIVERANCE_BENCHMARK_ARGS="--owner tjake --model gemma-2-2b-it --adapter-owner someuser --adapter-model some-lora-adapter --output target/gemma-lora.csv --jsonl-output target/gemma-lora.jsonl --max-tokens 128 --profile-stages" \
+./benchmarks/run-lora-adapter-benchmark.sh
+```
+
+The base model must be dense (F32/BF16/F16 on disk) -- a pre-quantized-on-disk base model (e.g.
+the `-JQ4` repos used by the other scripts on this page) is out of scope for merge-at-load and
+will fail fast with a clear exception.
+
 ### Qwen Single-Model Benchmark
 
 ```sh

--- a/core/src/main/java/io/teknek/deliverance/benchmark/LoraAdapterBenchmark.java
+++ b/core/src/main/java/io/teknek/deliverance/benchmark/LoraAdapterBenchmark.java
@@ -1,0 +1,222 @@
+package io.teknek.deliverance.benchmark;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.teknek.deliverance.JsonUtils;
+import io.teknek.deliverance.generator.GeneratorParameters;
+import io.teknek.deliverance.generator.Response;
+import io.teknek.deliverance.math.WrappedForkJoinPool;
+import io.teknek.deliverance.model.AbstractModel;
+import io.teknek.deliverance.model.AutoModelForCausaLm;
+import io.teknek.deliverance.model.DoNothingGenerateEvent;
+import io.teknek.deliverance.model.InferenceProfiler;
+import io.teknek.deliverance.safetensors.fetch.LoraAdapterModelFetcher;
+import io.teknek.deliverance.safetensors.fetch.ModelFetcher;
+import io.teknek.deliverance.safetensors.prompt.PromptSupport;
+
+import java.io.BufferedWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Compares an un-adapted base model against the same base model with a LoRA adapter merged in
+ * (Phase 1 "merge-at-load", {@link io.teknek.deliverance.safetensors.MergingWeightLoader}), added
+ * per the maintainer's PR feedback that new features should ship with a profiled, example-
+ * generating benchmark -- see {@code StepPlans/deliverance_lora_step3_merging_weightloader_plan_v1.md}
+ * Section 6.
+ *
+ * <p>Structural template is {@link ThinkingSmokeBenchmark} (one model at a time, hand-rolled CLI,
+ * small fixed prompt list), not {@link InferenceBenchmark} (multi-engine, tensor-parallel-aware) --
+ * but the CSV column set is deliberately identical to {@link InferenceBenchmark}'s documented
+ * columns, plus a {@code variant} column distinguishing {@code base} from {@code lora-adapted}
+ * rows, so the same row can be diffed/filtered across both variants to surface the adapter's
+ * overhead directly.</p>
+ */
+public final class LoraAdapterBenchmark {
+    private static final String CSV_HEADER = String.join(",",
+            "timestamp",
+            "variant",
+            "model",
+            "case_id",
+            "category",
+            "prompt_chars",
+            "prompt_tokens",
+            "generated_tokens",
+            "total_ms",
+            "generation_ms",
+            "tokens_per_second",
+            "response_chars",
+            "finish_reason");
+
+    private LoraAdapterBenchmark() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        Options options = Options.parse(args);
+        if (options.output.getParent() != null) {
+            Files.createDirectories(options.output.getParent());
+        }
+        if (options.jsonlOutput.getParent() != null) {
+            Files.createDirectories(options.jsonlOutput.getParent());
+        }
+        InferenceProfiler.setEnabled(options.profileStages);
+
+        try (BufferedWriter csv = Files.newBufferedWriter(options.output, StandardCharsets.UTF_8);
+                BufferedWriter jsonl = Files.newBufferedWriter(options.jsonlOutput, StandardCharsets.UTF_8)) {
+            csv.write(CSV_HEADER);
+            csv.newLine();
+            csv.flush();
+            System.out.println("writing benchmark results to " + options.output.toAbsolutePath());
+            System.out.println("writing benchmark transcripts to " + options.jsonlOutput.toAbsolutePath());
+
+            ModelFetcher fetcher = new ModelFetcher(options.owner, options.model);
+            String modelName = options.owner + "/" + options.model;
+
+            System.out.println("[lora-adapter-benchmark] loading base model " + modelName);
+            try (AbstractModel base = AutoModelForCausaLm.newBuilder(fetcher)
+                    .withWrappedForkJoinPool(new WrappedForkJoinPool(WrappedForkJoinPool.autoSizeByCores()))
+                    .buildLocalTransformerModel()) {
+                runVariant("base", modelName, base, options, csv, jsonl);
+            }
+
+            String adapterName = options.adapterOwner + "/" + options.adapterModel;
+            System.out.println("[lora-adapter-benchmark] loading base model " + modelName
+                    + " with LoRA adapter " + adapterName + " merged in");
+            try (AbstractModel adapted = AutoModelForCausaLm.newBuilder(fetcher)
+                    .withWrappedForkJoinPool(new WrappedForkJoinPool(WrappedForkJoinPool.autoSizeByCores()))
+                    .withLoraAdapter(new LoraAdapterModelFetcher(options.adapterOwner, options.adapterModel))
+                    .buildLocalTransformerModel()) {
+                runVariant("lora-adapted", modelName + "+" + adapterName, adapted, options, csv, jsonl);
+            }
+        }
+        System.out.println("wrote benchmark results to " + options.output.toAbsolutePath());
+    }
+
+    private static void runVariant(String variant, String modelLabel, AbstractModel model, Options options,
+            BufferedWriter csv, BufferedWriter jsonl) throws Exception {
+        for (PromptCase promptCase : promptCases()) {
+            InferenceProfiler.reset();
+            PromptSupport.Builder promptBuilder = model.promptSupport().orElseThrow().builder()
+                    .addUserMessage(promptCase.prompt);
+            var promptContext = promptBuilder.build();
+
+            long start = System.nanoTime();
+            Response response = model.generate(UUID.randomUUID(), promptContext,
+                    new GeneratorParameters().withTemperature(options.temperature).withMaxTokens(options.maxTokens),
+                    new DoNothingGenerateEvent());
+            double totalMs = (System.nanoTime() - start) / 1_000_000.0;
+
+            double timeToFirstTokenMs = response.timeToFirstTokenMs;
+            double generationMs = Math.max(0.0, totalMs - timeToFirstTokenMs);
+            long decodeTokens = Math.max(0, response.generatedTokens.size() - 1L);
+            double tokensPerSecond = generationMs == 0.0 ? 0.0 : decodeTokens / (generationMs / 1000.0);
+
+            writeCsvRow(csv, variant, modelLabel, promptCase, promptContext.getPrompt().length(),
+                    response, totalMs, generationMs, tokensPerSecond);
+            writeJsonlRow(jsonl, variant, promptCase, promptContext.getPrompt(), response, totalMs, timeToFirstTokenMs);
+
+            System.out.printf(Locale.ROOT,
+                    "[lora-adapter-benchmark] variant=%s case=%s generated=%d total_ms=%.1f tok_s=%.2f finish=%s%n",
+                    variant, promptCase.id, response.generatedTokens.size(), totalMs, tokensPerSecond,
+                    response.finishReason == null ? "" : response.finishReason.name());
+            InferenceProfiler.printSummary("variant=" + variant + " case=" + promptCase.id, 20);
+        }
+    }
+
+    private static void writeCsvRow(BufferedWriter csv, String variant, String modelLabel, PromptCase promptCase,
+            int promptChars, Response response, double totalMs, double generationMs, double tokensPerSecond)
+            throws Exception {
+        csv.write(String.join(",",
+                csv(Instant.now().toString()),
+                csv(variant),
+                csv(modelLabel),
+                csv(promptCase.id),
+                csv(promptCase.category),
+                Integer.toString(promptChars),
+                Long.toString(response.promptTokens),
+                Long.toString(response.generatedTokens.size()),
+                String.format(Locale.ROOT, "%.3f", totalMs),
+                String.format(Locale.ROOT, "%.3f", generationMs),
+                String.format(Locale.ROOT, "%.3f", tokensPerSecond),
+                Integer.toString(response.responseText.length()),
+                csv(response.finishReason == null ? "" : response.finishReason.name())));
+        csv.newLine();
+        csv.flush();
+    }
+
+    private static void writeJsonlRow(BufferedWriter jsonl, String variant, PromptCase promptCase, String prompt,
+            Response response, double totalMs, double timeToFirstTokenMs) throws Exception {
+        ObjectNode row = JsonUtils.om.createObjectNode();
+        row.put("timestamp", Instant.now().toString());
+        row.put("case_id", promptCase.id);
+        row.put("variant", variant);
+        row.put("prompt", prompt);
+        row.put("response", response.responseText);
+        row.put("generated_tokens", response.generatedTokens.size());
+        row.put("time_ms", totalMs);
+        row.put("time_to_first_token_ms", timeToFirstTokenMs);
+        row.put("finish_reason", response.finishReason == null ? "" : response.finishReason.name());
+        jsonl.write(JsonUtils.om.writeValueAsString(row));
+        jsonl.newLine();
+        jsonl.flush();
+    }
+
+    private static String csv(String value) {
+        if (value == null) {
+            return "";
+        }
+        String escaped = value.replace("\"", "\"\"");
+        return "\"" + escaped + "\"";
+    }
+
+    private static List<PromptCase> promptCases() {
+        return List.of(
+                new PromptCase("greeting", "chat", "Hello! Who are you and what can you help me with?"),
+                new PromptCase("capital", "knowledge", "What is the capital of France? Answer in one word."),
+                new PromptCase("math", "math", "What is 17 times 6? Show your work briefly."),
+                new PromptCase("summary", "writing",
+                        "Summarize in two sentences: the water cycle moves water between the ocean, atmosphere, and "
+                                + "land through evaporation, condensation, and precipitation."),
+                new PromptCase("code", "coding", "Write a Python function that returns the nth Fibonacci number."),
+                new PromptCase("opinion", "reasoning", "What are the tradeoffs between electric and gas cars? Give two of each."));
+    }
+
+    private record PromptCase(String id, String category, String prompt) {
+    }
+
+    private record Options(String owner, String model, String adapterOwner, String adapterModel, Path output,
+            Path jsonlOutput, int maxTokens, float temperature, boolean profileStages) {
+        private static Options parse(String[] args) {
+            String owner = "unsloth";
+            String model = "Llama-3.2-1B-Instruct";
+            String adapterOwner = "bunnycore";
+            String adapterModel = "Llama-3.2-1b-chatml-lora_model";
+            Path output = Path.of("core/target/lora-adapter-benchmark.csv");
+            Path jsonlOutput = Path.of("core/target/lora-adapter-benchmark.jsonl");
+            int maxTokens = 128;
+            float temperature = 0.0f;
+            boolean profileStages = false;
+            for (int i = 0; i < args.length; i++) {
+                switch (args[i]) {
+                    case "--owner" -> owner = args[++i];
+                    case "--model" -> model = args[++i];
+                    case "--adapter-owner" -> adapterOwner = args[++i];
+                    case "--adapter-model" -> adapterModel = args[++i];
+                    case "--output" -> output = Path.of(args[++i]);
+                    case "--jsonl-output" -> jsonlOutput = Path.of(args[++i]);
+                    case "--max-tokens" -> maxTokens = Integer.parseInt(args[++i]);
+                    case "--temperature" -> temperature = Float.parseFloat(args[++i]);
+                    case "--profile-stages" -> profileStages = true;
+                    default -> throw new IllegalArgumentException("unknown argument: " + args[i]);
+                }
+            }
+            return new Options(owner, model, adapterOwner, adapterModel, output, jsonlOutput, maxTokens, temperature,
+                    profileStages);
+        }
+    }
+}

--- a/core/src/main/java/io/teknek/deliverance/model/AutoModelForCausaLm.java
+++ b/core/src/main/java/io/teknek/deliverance/model/AutoModelForCausaLm.java
@@ -9,7 +9,9 @@ import io.teknek.deliverance.model.tensorparallel.GossipParallelMembership;
 import io.teknek.deliverance.model.tensorparallel.GossipParallelSettings;
 import io.teknek.deliverance.model.tensorparallel.TensorParallelCollectives;
 import io.teknek.deliverance.model.tensorparallel.TensorParallelContext;
+import io.teknek.deliverance.safetensors.LoraAdapter;
 import io.teknek.deliverance.safetensors.ModelQuantizer;
+import io.teknek.deliverance.safetensors.fetch.LoraAdapterModelFetcher;
 import io.teknek.deliverance.safetensors.fetch.ModelFetcher;
 import io.teknek.deliverance.tensor.ArrayQueueTensorAllocator;
 import io.teknek.deliverance.tensor.TensorAllocator;
@@ -88,6 +90,7 @@ public class AutoModelForCausaLm {
         private Optional<GossipParallelSettings> parallelSettings = Optional.empty();
         private Optional<DType> outputHeadQuantization = Optional.empty();
         private Optional<QuantizeOnDemand> quantizeOnDemand = Optional.empty();
+        private LoraAdapterModelFetcher loraAdapterFetcher;
         private final EnumMap<TensorProviderKind, TensorOperations> additionalTensorOperations = new EnumMap<>(TensorProviderKind.class);
         private boolean download = true;
         private int maxBatchSize = AbstractModel.DEFAULT_MAX_BATCH_SIZE;
@@ -225,6 +228,20 @@ public class AutoModelForCausaLm {
             return this;
         }
 
+        /**
+         * Merges the given LoRA/PEFT adapter into the base model's weights at load time (Phase 1
+         * "merge-at-load" -- see {@code
+         * StepPlans/deliverance_lora_step3_merging_weightloader_plan_v1.md}). The base model is
+         * loaded and merged fresh on every {@link #build()}/{@link #buildLocalTransformerModel()}
+         * call; nothing is cached to disk. Requires a dense (F32/BF16/F16) base model and does not
+         * support tensor-parallel loading -- both are enforced with a clear exception at load time
+         * rather than silently producing an unmerged or wrong model.
+         */
+        public Builder withLoraAdapter(LoraAdapterModelFetcher adapterFetcher) {
+            this.loraAdapterFetcher = adapterFetcher;
+            return this;
+        }
+
         /** Applies a JSON-friendly builder configuration object. Explicit method calls made after this one can override it. */
         public Builder withConfig(AutoModelConfig config) {
             Objects.requireNonNull(config, "config");
@@ -297,6 +314,7 @@ public class AutoModelForCausaLm {
             copy.tensorParallelCollectives = Objects.requireNonNull(collectives, "collectives");
             copy.outputHeadQuantization = this.outputHeadQuantization;
             copy.quantizeOnDemand = this.quantizeOnDemand;
+            copy.loraAdapterFetcher = this.loraAdapterFetcher;
             copy.additionalTensorOperations.putAll(this.additionalTensorOperations);
             copy.download = this.download;
             copy.maxBatchSize = this.maxBatchSize;
@@ -353,9 +371,12 @@ public class AutoModelForCausaLm {
                 Optional<TensorOperations> maybe = getNative(base.get());
                 provider = maybe.map(ConfigurableTensorProvider::new).orElse(base);
             }
+            Optional<LoraAdapter> loraAdapter = loraAdapterFetcher == null
+                    ? Optional.empty()
+                    : Optional.of(LoraAdapter.fromPretrained(loraAdapterFetcher, mr));
             AbstractModel model = ModelSupport.loadModel(modelRoot, workingMem, workingQuant, provider,
                     mr, allocator, settings, fetcherForLoad, toolCallParser, pool, tensorParallelContext, tensorParallelCollectives,
-                    outputHeadQuantization);
+                    outputHeadQuantization, loraAdapter);
             model.setMaxBatchSize(maxBatchSize);
             model.setTensorProviderExplicit(tensorProviderExplicit);
             if (!tensorProviderExplicit) {

--- a/core/src/main/java/io/teknek/deliverance/model/ModelSupport.java
+++ b/core/src/main/java/io/teknek/deliverance/model/ModelSupport.java
@@ -127,6 +127,30 @@ public class ModelSupport {
                                              TensorParallelContext tensorParallelContext,
                                              TensorParallelCollectives tensorParallelCollectives,
                                              Optional<DType> outputHeadQuantization) {
+        return loadModel(model, workingMemoryType, workingQuantizationType, configurableTensorProvider, metricRegistry,
+                arrayQueueTensorAllocator, kvBufferCacheSettings, fetcher, toolCallParser, pool,
+                tensorParallelContext, tensorParallelCollectives, outputHeadQuantization, Optional.empty());
+    }
+
+    /**
+     * As above, with an optional LoRA adapter merged into the base model's weights at load time
+     * (Phase 1 "merge-at-load" support -- see {@code
+     * StepPlans/deliverance_lora_step3_merging_weightloader_plan_v1.md}). When {@code loraAdapter}
+     * is present, the {@link WeightLoader} handed to the model family constructor is a {@link
+     * MergingWeightLoader} wrapping the usual {@link DefaultWeightLoader}; every other call site
+     * (the 13-arg overload above, and every other overload in this class) is unaffected and keeps
+     * loading models without any LoRA merge.
+     */
+    public static AbstractModel loadModel(File model, DType workingMemoryType, DType workingQuantizationType,
+                                             ConfigurableTensorProvider configurableTensorProvider,
+                                             MetricRegistry metricRegistry, TensorAllocator arrayQueueTensorAllocator,
+                                             KvBufferCacheSettings kvBufferCacheSettings,
+                                             ModelFetcher fetcher, ToolCallParser toolCallParser,
+                                             WrappedForkJoinPool pool,
+                                             TensorParallelContext tensorParallelContext,
+                                             TensorParallelCollectives tensorParallelCollectives,
+                                             Optional<DType> outputHeadQuantization,
+                                             Optional<LoraAdapter> loraAdapter) {
         LOGGER.info("Machine Vector Spec: {} Byte Order: {}", FloatVector.SPECIES_PREFERRED.vectorBitSize(), ByteOrder.nativeOrder().toString());
         File configFile = new File(model, "config.json");
         if (!configFile.exists()){
@@ -137,6 +161,9 @@ public class ModelSupport {
             Config config = om.readValue(configFile, modelType.getConfigClass());
             PreTrainedTokenizer tokenizer = AutoTokenizer.fromPretrained(model.toPath());
             WeightLoader wl = new DefaultWeightLoader(model);
+            if (loraAdapter.isPresent()) {
+                wl = new MergingWeightLoader(wl, loraAdapter.get(), configurableTensorProvider.get());
+            }
 
             Constructor<? extends AbstractModel> cons = modelType.getModelClass().getConstructor(AbstractModel.InferenceType.class, Config.class,
                     WeightLoader.class, PreTrainedTokenizer.class, DType.class, DType.class, Optional.class,

--- a/core/src/test/java/io/teknek/deliverance/integration/MergingWeightLoaderIntegrationTest.java
+++ b/core/src/test/java/io/teknek/deliverance/integration/MergingWeightLoaderIntegrationTest.java
@@ -1,0 +1,64 @@
+package io.teknek.deliverance.integration;
+
+import io.teknek.deliverance.generator.GeneratorParameters;
+import io.teknek.deliverance.generator.Response;
+import io.teknek.deliverance.model.AbstractModel;
+import io.teknek.deliverance.model.AutoModelForCausaLm;
+import io.teknek.deliverance.model.DoNothingGenerateEvent;
+import io.teknek.deliverance.safetensors.fetch.LoraAdapterModelFetcher;
+import io.teknek.deliverance.safetensors.fetch.ModelFetcher;
+import io.teknek.deliverance.safetensors.prompt.PromptSupport;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * End-to-end check for Phase 1 "merge-at-load" LoRA support ({@link
+ * io.teknek.deliverance.safetensors.MergingWeightLoader} wired through {@link
+ * AutoModelForCausaLm.Builder#withLoraAdapter}), per {@code
+ * StepPlans/deliverance_lora_step3_merging_weightloader_plan_v1.md} Section 7. Requires network
+ * access to download the base model and adapter, same as the other tests in this package.
+ *
+ * <p>Uses {@code unsloth/Llama-3.2-1B-Instruct} (dense HF format, required by {@link
+ * io.teknek.deliverance.safetensors.MergingWeightLoader}'s dtype guard) paired with {@code
+ * bunnycore/Llama-3.2-1b-chatml-lora_model}, the same base/adapter pairing already verified in
+ * {@code LoraAdapterTest} -- deliberately not {@code tjake/Llama-3.2-1B-Instruct-JQ4}, which is
+ * pre-quantized on disk and out of scope for merge-at-load (Section 1 item 4 of the step 3
+ * plan).</p>
+ */
+public class MergingWeightLoaderIntegrationTest {
+
+    private static final String PROMPT = "Hello! Who are you and what can you help me with?";
+
+    @Test
+    public void loraAdaptedGenerationDiffersFromBaseModel() {
+        ModelFetcher fetcher = new ModelFetcher("unsloth", "Llama-3.2-1B-Instruct");
+
+        String baseResponse;
+        try (AbstractModel base = AutoModelForCausaLm.newBuilder(fetcher).buildLocalTransformerModel()) {
+            baseResponse = generate(base);
+        }
+
+        String adaptedResponse;
+        try (AbstractModel adapted = AutoModelForCausaLm.newBuilder(fetcher)
+                .withLoraAdapter(new LoraAdapterModelFetcher("bunnycore", "Llama-3.2-1b-chatml-lora_model"))
+                .buildLocalTransformerModel()) {
+            adaptedResponse = generate(adapted);
+        }
+
+        System.out.println("[base] " + baseResponse);
+        System.out.println("[lora-adapted] " + adaptedResponse);
+        assertNotEquals(baseResponse, adaptedResponse,
+                "LoRA-adapted generation should measurably differ from the un-adapted base model");
+    }
+
+    private static String generate(AbstractModel model) {
+        PromptSupport.Builder promptBuilder = model.promptSupport().orElseThrow().builder().addUserMessage(PROMPT);
+        Response response = model.generate(UUID.randomUUID(), promptBuilder.build(),
+                new GeneratorParameters().withMaxTokens(80).withTemperature(0.0f).withSeed(42),
+                new DoNothingGenerateEvent());
+        return response.responseText;
+    }
+}

--- a/safetensors/src/main/java/io/teknek/deliverance/safetensors/LoraAdapter.java
+++ b/safetensors/src/main/java/io/teknek/deliverance/safetensors/LoraAdapter.java
@@ -63,7 +63,15 @@ public class LoraAdapter implements AutoCloseable {
                 ByteBuffer mapped = raf.getChannel().map(FileChannel.MapMode.READ_ONLY, 0, raf.length());
                 Map<String, String> metadata = new java.util.HashMap<>();
                 Map<String, TensorInfo> tensorInfoMap = DefaultWeightLoader.readTensorInfoMap(mapped, Optional.of(metadata));
-                Weights weights = new Weights(metadata, tensorInfoMap, mapped, Optional.empty());
+                // readTensorInfoMap only advances mapped's position past the header; TensorInfo's
+                // dataOffsets are 0-based from the start of the tensor-data section, but Weights#load
+                // seeks with an *absolute* ByteBuffer#position(), so a duplicate() of mapped as-is would
+                // silently re-seek into the header/earlier tensors instead of skipping past them. slice()
+                // fixes that by making the tensor-data section start at index 0 of the buffer Weights sees
+                // -- the same effect DefaultWeightLoader gets by mapping a fresh region starting after the
+                // header instead of reusing one buffer across the header and the data.
+                ByteBuffer tensorData = mapped.slice();
+                Weights weights = new Weights(metadata, tensorInfoMap, tensorData, Optional.empty());
                 return new LoraAdapter(config, weights, raf, metricRegistry);
             } catch (RuntimeException | Error e) {
                 closeQuietly(raf);

--- a/safetensors/src/main/java/io/teknek/deliverance/safetensors/MergingWeightLoader.java
+++ b/safetensors/src/main/java/io/teknek/deliverance/safetensors/MergingWeightLoader.java
@@ -1,0 +1,171 @@
+package io.teknek.deliverance.safetensors;
+
+import com.google.common.primitives.Ints;
+import io.teknek.deliverance.DType;
+import io.teknek.deliverance.tensor.AbstractTensor;
+import io.teknek.deliverance.tensor.TensorInfo;
+import io.teknek.deliverance.tensor.TensorShape;
+import io.teknek.deliverance.tensor.impl.BFloat16BufferTensor;
+import io.teknek.deliverance.tensor.impl.Float16BufferTensor;
+import io.teknek.deliverance.tensor.impl.FloatBufferTensor;
+import io.teknek.deliverance.tensor.operations.TensorOperations;
+
+import java.util.Map;
+
+/**
+ * A {@link WeightLoader} decorator that merges a {@link LoraAdapter}'s low-rank deltas into the
+ * delegate loader's tensors at load time.
+ *
+ * <p>This is the Phase 1 ("merge-at-load") LoRA support described in {@code
+ * StepPlans/deliverance_lora_step3_merging_weightloader_plan_v1.md}: the merge is recomputed in
+ * memory on every model load, no new files are written, and model family classes (e.g. {@code
+ * LlamaModel}) are completely unaware this decorator exists -- they call {@link #load(String)}
+ * exactly as they would against a {@link DefaultWeightLoader}.</p>
+ */
+public class MergingWeightLoader implements WeightLoader {
+
+    private final WeightLoader delegate;
+    private final LoraAdapter adapter;
+    private final TensorOperations tensorOps;
+
+    public MergingWeightLoader(WeightLoader delegate, LoraAdapter adapter, TensorOperations tensorOps) {
+        this.delegate = delegate;
+        this.adapter = adapter;
+        this.tensorOps = tensorOps;
+        DType baseDType = delegate.getModelDType();
+        if (baseDType != DType.F32 && baseDType != DType.BF16 && baseDType != DType.F16) {
+            throw new UnsupportedOperationException(
+                    "LoRA merge-at-load requires a dense (F32/BF16/F16) base model; got " + baseDType
+                            + " -- pre-quantized-on-disk base models are not supported for merge-at-load");
+        }
+    }
+
+    @Override
+    public Map<String, String> metadata() {
+        return delegate.metadata();
+    }
+
+    @Override
+    public Map<String, TensorInfo> tensorInfoMap() {
+        return delegate.tensorInfoMap();
+    }
+
+    @Override
+    public DType getModelDType() {
+        return delegate.getModelDType();
+    }
+
+    @Override
+    public boolean isWeightPresent(String name) {
+        return delegate.isWeightPresent(name);
+    }
+
+    @Override
+    public AbstractTensor load(String name) {
+        AbstractTensor base = delegate.load(name);
+        return adapter.deltaFor(name).map(delta -> merge(base, delta)).orElse(base);
+    }
+
+    @Override
+    public AbstractTensor loadRows(String name, int rowOffset, int rowCount) {
+        if (adapter.deltaFor(name).isPresent()) {
+            throw new UnsupportedOperationException(
+                    "LoRA merge-at-load does not support partial-row loading for targeted module: " + name);
+        }
+        return delegate.loadRows(name, rowOffset, rowCount);
+    }
+
+    @Override
+    public AbstractTensor load(String name, TensorShardSpec shardSpec) {
+        if (adapter.deltaFor(name).isPresent()) {
+            throw new UnsupportedOperationException(
+                    "LoRA merge-at-load does not support tensor-parallel sharded loading for targeted module: "
+                            + name + " -- tensor-parallel + LoRA is an explicit non-goal for this PR");
+        }
+        return delegate.load(name, shardSpec);
+    }
+
+    /** Closes both the delegate loader and the adapter -- this loader is the adapter's sole owner. */
+    @Override
+    public void close() throws Exception {
+        try {
+            delegate.close();
+        } finally {
+            adapter.close();
+        }
+    }
+
+    /**
+     * Computes {@code base + scale * (loraB @ loraA)} and returns a freshly allocated tensor;
+     * {@code base} is left untouched.
+     *
+     * <p>{@code base} has shape {@code [out, in]}. {@code loraA} has shape {@code [rank, in]} and
+     * {@code loraB} has shape {@code [out, rank]} (standard PEFT layout). For each output row
+     * {@code o}, {@code delta[o,:] = scale * sum_k loraB[o,k] * loraA[k,:]} -- exactly what {@link
+     * TensorOperations}'s batched {@code saxpy} computes when given one row of (pre-scaled) {@code
+     * loraB} as {@code alpha} and all of {@code loraA} as {@code x}. The batched primitive requires
+     * both its {@code alpha} and {@code y} arguments to be single-row tensors, so this loops over
+     * output rows, slicing one row of {@code merged} (as {@code y}) and one row of {@code scaledB}
+     * (as {@code alpha}) per iteration -- both slices are views over the allocated tensors, not
+     * copies, so the accumulation writes straight into {@code merged}.</p>
+     *
+     * <p>{@code loraA}/{@code loraB} are converted to {@code base}'s dtype first: the underlying
+     * {@code saxpy} implementations only support matching dtypes, or a BF16 {@code x} against an F32
+     * {@code y}, and a real-world adapter's stored dtype (commonly F32) has no guaranteed relationship
+     * to the base model's dtype (commonly BF16 for HF-distributed dense checkpoints). {@code loraB} is
+     * pre-scaled by {@code adapter.scale()} during that same conversion pass rather than via {@link
+     * TensorOperations#scale}: on this codebase's ARM/Panama path, {@code scale()} only implements BF16
+     * for AVX_512/AVX_256 and has no native ARM kernel (unlike {@code saxpy}, which does fall back
+     * correctly for BF16), so calling it here would make merging fail on BF16 base models under ARM.</p>
+     */
+    private AbstractTensor merge(AbstractTensor base, LoraAdapter.LoraDelta delta) {
+        int outFeatures = base.shape().first();
+        int inFeatures = base.shape().last();
+        int rank = delta.loraA().shape().first();
+
+        AbstractTensor merged = allocateLike(base.dType(), outFeatures, inFeatures);
+        merged.copyFrom(base, 0, 0, Ints.checkedCast(base.size()));
+
+        AbstractTensor loraA = toDType(delta.loraA(), base.dType());
+        AbstractTensor scaledB = scaledCopy(delta.loraB(), base.dType(), (float) adapter.scale());
+
+        for (int o = 0; o < outFeatures; o++) {
+            AbstractTensor mergedRow = merged.slice(o);
+            AbstractTensor scaledBRow = scaledB.slice(o);
+            tensorOps.saxpy(scaledBRow, loraA, mergedRow, 0, 0, inFeatures, 0, 0, rank);
+        }
+        return merged;
+    }
+
+    private static AbstractTensor toDType(AbstractTensor src, DType target) {
+        if (src.dType() == target) {
+            return src;
+        }
+        return scaledCopy(src, target, 1.0f);
+    }
+
+    private static AbstractTensor scaledCopy(AbstractTensor src, DType target, float factor) {
+        AbstractTensor converted = allocateLike(target, src.shape().first(), src.shape().last());
+        for (int row = 0; row < src.shape().first(); row++) {
+            for (int col = 0; col < src.shape().last(); col++) {
+                converted.set(src.get(row, col) * factor, row, col);
+            }
+        }
+        return converted;
+    }
+
+    /**
+     * Duplicated from {@link DefaultWeightLoader}'s private {@code allocateLike} rather than
+     * extracted into a shared utility -- see Section 11 of the step 3 plan for why this PR keeps
+     * the two copies independent.
+     */
+    private static AbstractTensor allocateLike(DType dType, int rows, int cols) {
+        TensorShape shape = TensorShape.of(rows, cols);
+        return switch (dType) {
+            case F32 -> new FloatBufferTensor(shape);
+            case BF16 -> new BFloat16BufferTensor(shape);
+            case F16 -> new Float16BufferTensor(shape);
+            default -> throw new UnsupportedOperationException("Unsupported dtype for LoRA merge: " + dType);
+        };
+    }
+}

--- a/safetensors/src/test/java/io/teknek/deliverance/safetensors/MergingWeightLoaderTest.java
+++ b/safetensors/src/test/java/io/teknek/deliverance/safetensors/MergingWeightLoaderTest.java
@@ -1,0 +1,198 @@
+package io.teknek.deliverance.safetensors;
+
+import io.teknek.deliverance.DType;
+import io.teknek.deliverance.tensor.AbstractTensor;
+import io.teknek.deliverance.tensor.TensorInfo;
+import io.teknek.deliverance.tensor.impl.FloatBufferTensor;
+import io.teknek.deliverance.tensor.operations.NaiveTensorOperations;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies {@link MergingWeightLoader}'s merge math against a naive plain-Java reference
+ * calculation on small synthetic tensors, per {@code
+ * StepPlans/deliverance_lora_step3_merging_weightloader_plan_v1.md} Section 7. No network access;
+ * base model and adapter are both synthetic directories built with {@link SafeTensorWriter}, the
+ * same pattern {@link LoraAdapterTest} already uses for its no-network cases.
+ */
+public class MergingWeightLoaderTest {
+
+    private static final String Q_PROJ = "model.layers.0.self_attn.q_proj.weight";
+    private static final String K_PROJ = "model.layers.0.self_attn.k_proj.weight";
+    private static final int OUT_FEATURES = 4;
+    private static final int IN_FEATURES = 4;
+    private static final int RANK = 2;
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void mergesDeltaIntoTargetedModule() throws IOException {
+        Path baseDir = tempDir.resolve("base");
+        Path adapterDir = tempDir.resolve("adapter");
+
+        float[][] base = matrix(new float[][] {
+                { 1f, 2f, 3f, 4f },
+                { 5f, 6f, 7f, 8f },
+                { 9f, 10f, 11f, 12f },
+                { 13f, 14f, 15f, 16f } });
+        float[][] loraA = matrix(new float[][] {
+                { 0.1f, 0.2f, 0.3f, 0.4f },
+                { 0.5f, 0.6f, 0.7f, 0.8f } });
+        float[][] loraB = matrix(new float[][] {
+                { 1f, 2f },
+                { 3f, 4f },
+                { 5f, 6f },
+                { 7f, 8f } });
+        double alpha = 4.0;
+        double rank = RANK;
+        double scale = alpha / rank;
+
+        writeBaseModel(baseDir, Map.of(Q_PROJ, base, K_PROJ, base));
+        writeAdapter(adapterDir, RANK, alpha, "q_proj", Map.of(
+                LoraTensorNames.loraA(Q_PROJ), loraA,
+                LoraTensorNames.loraB(Q_PROJ), loraB));
+
+        float[][] expected = new float[OUT_FEATURES][IN_FEATURES];
+        for (int o = 0; o < OUT_FEATURES; o++) {
+            for (int i = 0; i < IN_FEATURES; i++) {
+                double delta = 0;
+                for (int k = 0; k < RANK; k++) {
+                    delta += loraB[o][k] * loraA[k][i];
+                }
+                expected[o][i] = (float) (base[o][i] + scale * delta);
+            }
+        }
+
+        try (DefaultWeightLoader delegate = DefaultWeightLoader.open(baseDir.toFile());
+                LoraAdapter adapter = LoraAdapter.load(adapterDir.toFile())) {
+            MergingWeightLoader merging = new MergingWeightLoader(delegate, adapter, new NaiveTensorOperations());
+            try (AbstractTensor merged = merging.load(Q_PROJ)) {
+                for (int o = 0; o < OUT_FEATURES; o++) {
+                    for (int i = 0; i < IN_FEATURES; i++) {
+                        assertEquals(expected[o][i], merged.get(o, i), 1e-4f,
+                                "mismatch at [" + o + "," + i + "]");
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    void passesThroughNonTargetedModuleUnchanged() throws IOException {
+        Path baseDir = tempDir.resolve("base");
+        Path adapterDir = tempDir.resolve("adapter");
+
+        float[][] base = matrix(new float[][] {
+                { 1f, 2f, 3f, 4f },
+                { 5f, 6f, 7f, 8f },
+                { 9f, 10f, 11f, 12f },
+                { 13f, 14f, 15f, 16f } });
+        float[][] loraA = matrix(new float[][] { { 0.1f, 0.2f, 0.3f, 0.4f }, { 0.5f, 0.6f, 0.7f, 0.8f } });
+        float[][] loraB = matrix(new float[][] { { 1f, 2f }, { 3f, 4f }, { 5f, 6f }, { 7f, 8f } });
+
+        writeBaseModel(baseDir, Map.of(Q_PROJ, base, K_PROJ, base));
+        writeAdapter(adapterDir, RANK, 4.0, "q_proj", Map.of(
+                LoraTensorNames.loraA(Q_PROJ), loraA,
+                LoraTensorNames.loraB(Q_PROJ), loraB));
+
+        try (DefaultWeightLoader delegate = DefaultWeightLoader.open(baseDir.toFile());
+                LoraAdapter adapter = LoraAdapter.load(adapterDir.toFile())) {
+            MergingWeightLoader merging = new MergingWeightLoader(delegate, adapter, new NaiveTensorOperations());
+            try (AbstractTensor unchanged = merging.load(K_PROJ)) {
+                for (int o = 0; o < OUT_FEATURES; o++) {
+                    for (int i = 0; i < IN_FEATURES; i++) {
+                        assertEquals(base[o][i], unchanged.get(o, i), 1e-6f);
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    void rejectsPreQuantizedOnDiskBaseModel() {
+        WeightLoader q4Delegate = new WeightLoader() {
+            @Override
+            public Map<String, String> metadata() {
+                return Map.of();
+            }
+
+            @Override
+            public Map<String, TensorInfo> tensorInfoMap() {
+                return Map.of();
+            }
+
+            @Override
+            public DType getModelDType() {
+                return DType.Q4;
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+        LoraAdapter adapter = null;
+        try {
+            Path adapterDir = tempDir.resolve("adapter");
+            float[][] loraA = matrix(new float[][] { { 0.1f, 0.2f, 0.3f, 0.4f }, { 0.5f, 0.6f, 0.7f, 0.8f } });
+            float[][] loraB = matrix(new float[][] { { 1f, 2f }, { 3f, 4f }, { 5f, 6f }, { 7f, 8f } });
+            writeAdapter(adapterDir, RANK, 4.0, "q_proj", Map.of(
+                    LoraTensorNames.loraA(Q_PROJ), loraA,
+                    LoraTensorNames.loraB(Q_PROJ), loraB));
+            adapter = LoraAdapter.load(adapterDir.toFile());
+            LoraAdapter finalAdapter = adapter;
+            assertThrows(UnsupportedOperationException.class,
+                    () -> new MergingWeightLoader(q4Delegate, finalAdapter, new NaiveTensorOperations()));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (adapter != null) {
+                adapter.close();
+            }
+        }
+    }
+
+    private static float[][] matrix(float[][] values) {
+        return values;
+    }
+
+    private static void writeBaseModel(Path baseDir, Map<String, float[][]> tensors) {
+        Map<String, AbstractTensor> asTensors = new LinkedHashMap<>();
+        for (Map.Entry<String, float[][]> entry : tensors.entrySet()) {
+            asTensors.put(entry.getKey(), toTensor(entry.getValue()));
+        }
+        SafeTensorWriter.writeModel(baseDir, Map.of(), asTensors);
+    }
+
+    private static void writeAdapter(Path adapterDir, int rank, double alpha, String targetModule,
+            Map<String, float[][]> tensors) throws IOException {
+        Files.createDirectories(adapterDir);
+        String json = "{\"r\": " + rank + ", \"lora_alpha\": " + alpha + ", \"target_modules\": [\"" + targetModule + "\"]}";
+        Files.writeString(adapterDir.resolve(LoraAdapterConfig.FILE_NAME), json);
+
+        Map<String, AbstractTensor> asTensors = new LinkedHashMap<>();
+        for (Map.Entry<String, float[][]> entry : tensors.entrySet()) {
+            asTensors.put(entry.getKey(), toTensor(entry.getValue()));
+        }
+        SafeTensorWriter.write(adapterDir.resolve(LoraAdapter.SAFETENSORS_FILE_NAME), Map.of(), asTensors);
+    }
+
+    private static AbstractTensor toTensor(float[][] values) {
+        FloatBufferTensor tensor = new FloatBufferTensor(values.length, values[0].length);
+        for (int r = 0; r < values.length; r++) {
+            for (int c = 0; c < values[r].length; c++) {
+                tensor.set(values[r][c], r, c);
+            }
+        }
+        return tensor;
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 LoRA/PEFT support, per the sequencing agreed after PR #153: merge a LoRA adapter's
low-rank deltas into a dense base model's weights **at load time**, so `LlamaModel` and every
other model family class need zero changes — they still just call `weights.load(name)` and
`quantize(...)` exactly as today.

- **`MergingWeightLoader`** (`safetensors`): a `WeightLoader` decorator. `load(name)` checks
  whether the adapter targets that tensor's module; if so, computes
  `base + scale * (loraB @ loraA)` via the existing batched `TensorOperations.saxpy` (no new
  tensor-math primitive), returning a freshly allocated tensor. `loadRows`/`load(..., shardSpec)`
  fail loudly (not silently) for a targeted module, since tensor-parallel + LoRA is an explicit
  non-goal for this PR.
- **`Builder.withLoraAdapter(LoraAdapterModelFetcher)`**, wired through a new 14-arg
  `ModelSupport.loadModel` overload (trailing `Optional<LoraAdapter>`); the existing 13-arg
  overload is untouched and delegates with `Optional.empty()`.
- **Dtype guard**: merge-at-load requires a dense (F32/BF16/F16) on-disk base model — a
  pre-quantized base (e.g. the `-JQ4` repos) throws a clear `UnsupportedOperationException` at
  load time rather than producing silently-wrong output.
- **`LoraAdapterBenchmark`** (+ `benchmarks/run-lora-adapter-benchmark.sh`,
  `core/benchmarking.md` section) — added per your PR #153 feedback asking for a profiled,
  example-generating benchmark. Loads the same base model once un-adapted and once with an
  adapter merged in, runs a small fixed prompt suite against both, and writes CSV (matching
  `InferenceBenchmark`'s documented columns, plus a `variant` column) and JSONL transcripts.

## Testing

- `MergingWeightLoaderTest` (unit, no network): merge math checked against a plain-Java naive
  reference on small synthetic tensors — a targeted module (merge applied), a non-targeted
  module (unchanged passthrough), and the pre-quantized-base guard.
- `MergingWeightLoaderIntegrationTest`: loads real `unsloth/Llama-3.2-1B-Instruct` +
  `bunnycore/Llama-3.2-1b-chatml-lora_model` (the same adapter used in #153), builds both an
  unmodified model and one via `.withLoraAdapter(...)`, and asserts the generations measurably
  differ. Passing example:
  - base: *"Hello! I'm an artificial intelligence model known as Llama. Llama stands for
    'Large Language Model Meta AI.'"*
  - lora-adapted: *"Hello! I'm an AI assistant, here to provide information and assistance on a
    wide range of topics. I'm happy to help you with any questions or concerns you may have."*
- `LoraAdapterBenchmark` run manually against the same pairing to sanity-check the CSV/JSONL
  output shape.

## Separate: bug fix in `LoraAdapter.load()` (already-merged #153)

While adding value-based assertions to `MergingWeightLoaderTest` (not just shape assertions,
which is all `LoraAdapterTest` checked), I found that `LoraAdapter.load()` was silently reading
every adapter tensor from the wrong file offset. It hands `Weights` the *entire* mmap'd file
buffer, with its position merely advanced past the header by `readTensorInfoMap`'s relative
`get()` calls. `Weights#load()` seeks with an **absolute** `ByteBuffer#position(dataOffsets[0])`
(0-based from the start of the tensor-data section), so the header-skip was silently undone on
every read.

Fix is one line: `ByteBuffer tensorData = mapped.slice()` before constructing `Weights`, so index
0 of the buffer `Weights` sees really is the start of the tensor data — the same effect
`DefaultWeightLoader` gets by mapping a fresh region starting after the header instead of reusing
one buffer across the header and the data. Bundled into this PR rather than filed separately
since `MergingWeightLoaderTest` is what surfaced it and depends on the fix to pass, but flagging
it explicitly here since it's a correctness fix to already-merged code, not new functionality.

## Non-goals (unchanged from the original proposal)

- Tensor-parallel + LoRA (enforced via exception in `load(..., shardSpec)`).
- Native SIMD/GPU acceleration of the merge.
- Runtime hot-swap (Phase 2, next PR).
- Merging onto a pre-quantized-on-disk base model (enforced via exception in the constructor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)