### PR TITLE
Add LoRA runtime hot-swap support (PR #4)

### DIFF
--- a/core/src/main/java/io/teknek/deliverance/generator/CausalSelfAttention.java
+++ b/core/src/main/java/io/teknek/deliverance/generator/CausalSelfAttention.java
@@ -52,6 +52,19 @@ public class CausalSelfAttention extends BaseCausalSelfAttention {
 
     private final MetricRegistry metricRegistry;
 
+    /**
+     * Base tensor names for this layer's q/k/v/o projections (e.g.
+     * {@code "model.layers.3.self_attn.q_proj.weight"}), used to look up an active LoRA adapter's
+     * delta for this layer via {@link AbstractModel#activeLoraDeltaFor(String)}. {@code null} for
+     * model families that haven't opted into LoRA runtime hot-swap (see step 4 plan Section 6) --
+     * safe because {@code activeLoraDeltaFor} never consults the name when no adapter is active,
+     * and non-opted-in families can never have one.
+     */
+    private final String queryWeightName;
+    private final String keyWeightName;
+    private final String valueWeightName;
+    private final String outputWeightName;
+
     public CausalSelfAttention(
             AbstractModel m,
             int layerIndex,
@@ -65,6 +78,37 @@ public class CausalSelfAttention extends BaseCausalSelfAttention {
         this(
                 m,
                 layerIndex,
+                queryAttnWeights,
+                keyAttnWeights,
+                valueAttnWeights,
+                outputProjectionWeights,
+                configurableTensorProvider,
+                metricRegistry,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+    /** Variant carrying base tensor names for LoRA runtime hot-swap -- see step 4 plan Section 4.1. */
+    public CausalSelfAttention(
+            AbstractModel m,
+            int layerIndex,
+            AbstractTensor queryAttnWeights,
+            AbstractTensor keyAttnWeights,
+            AbstractTensor valueAttnWeights,
+            AbstractTensor outputProjectionWeights,
+            ConfigurableTensorProvider configurableTensorProvider,
+            MetricRegistry metricRegistry,
+            String queryWeightName,
+            String keyWeightName,
+            String valueWeightName,
+            String outputWeightName
+    ) {
+        this(
+                m,
+                layerIndex,
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
@@ -74,7 +118,11 @@ public class CausalSelfAttention extends BaseCausalSelfAttention {
                 Optional.empty(),
                 outputProjectionWeights,
                 configurableTensorProvider,
-                metricRegistry
+                metricRegistry,
+                queryWeightName,
+                keyWeightName,
+                valueWeightName,
+                outputWeightName
         );
     }
 
@@ -91,6 +139,45 @@ public class CausalSelfAttention extends BaseCausalSelfAttention {
             AbstractTensor outputProjectionWeights,
             ConfigurableTensorProvider configurableTensorProvider,
             MetricRegistry metricRegistry
+    ) {
+        this(
+                m,
+                layerIndex,
+                queryAttnBias,
+                keyAttnBias,
+                valueAttnBias,
+                queryAttnWeights,
+                keyAttnWeights,
+                valueAttnWeights,
+                outputProjectionBias,
+                outputProjectionWeights,
+                configurableTensorProvider,
+                metricRegistry,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+    /** Canonical constructor, carrying base tensor names for LoRA runtime hot-swap -- see step 4 plan Section 4.1. */
+    public CausalSelfAttention(
+            AbstractModel m,
+            int layerIndex,
+            Optional<AbstractTensor> queryAttnBias,
+            Optional<AbstractTensor> keyAttnBias,
+            Optional<AbstractTensor> valueAttnBias,
+            AbstractTensor queryAttnWeights,
+            AbstractTensor keyAttnWeights,
+            AbstractTensor valueAttnWeights,
+            Optional<AbstractTensor> outputProjectionBias,
+            AbstractTensor outputProjectionWeights,
+            ConfigurableTensorProvider configurableTensorProvider,
+            MetricRegistry metricRegistry,
+            String queryWeightName,
+            String keyWeightName,
+            String valueWeightName,
+            String outputWeightName
     ) {
         this.m = m;
         this.layerIndex = layerIndex;
@@ -122,6 +209,10 @@ public class CausalSelfAttention extends BaseCausalSelfAttention {
         configurableTensorProvider.get().registerModelTensor(outputProjectionWeights);
 
         this.metricRegistry = metricRegistry;
+        this.queryWeightName = queryWeightName;
+        this.keyWeightName = keyWeightName;
+        this.valueWeightName = valueWeightName;
+        this.outputWeightName = outputWeightName;
     }
 
     public AbstractTensor forward(AbstractTensor input, int startPosition, KvBufferCache.KvBuffer kvMem,
@@ -188,6 +279,12 @@ public class CausalSelfAttention extends BaseCausalSelfAttention {
                     bias -> configurableTensorProvider.get().accumulate(tmpValBatch, bias,
                             0, kvLength)
             );
+            m.activeLoraDeltaFor(queryWeightName).ifPresent(
+                    delta -> LoraDeltaApplier.apply(m, queryBatch, input, delta));
+            m.activeLoraDeltaFor(keyWeightName).ifPresent(
+                    delta -> LoraDeltaApplier.apply(m, tmpKeyBatch, input, delta));
+            m.activeLoraDeltaFor(valueWeightName).ifPresent(
+                    delta -> LoraDeltaApplier.apply(m, tmpValBatch, input, delta));
             normalizeQueryKey(queryBatch, tmpKeyBatch);
             m.emitLayerDebug(layerIndex, "query_projection", queryBatch);
             m.emitLayerDebug(layerIndex, "key_projection", tmpKeyBatch);
@@ -366,6 +463,10 @@ public class CausalSelfAttention extends BaseCausalSelfAttention {
                 m.emitLayerDebug(layerIndex, "attention_output", reduced);
                 tensorReducer.ifPresent(func -> func.accept(Collections.singletonList(reduced)));
                 outputProjectionBias.ifPresent(bias -> configurableTensorProvider.get().accumulate(reduced, bias, 0, config.embeddingLength));
+                // vq is whatever the base o_proj matmul itself consumes; LoraDeltaApplier dequantizes it to
+                // match loraA's dtype internally -- see step 4 plan Section 11 item 9 (revised).
+                m.activeLoraDeltaFor(outputWeightName).ifPresent(
+                        delta -> LoraDeltaApplier.apply(m, reduced, vq, delta));
                 if (reduced != result) {
                     result.close();
                 }

--- a/core/src/main/java/io/teknek/deliverance/generator/LoraDeltaApplier.java
+++ b/core/src/main/java/io/teknek/deliverance/generator/LoraDeltaApplier.java
@@ -1,0 +1,85 @@
+package io.teknek.deliverance.generator;
+
+import io.teknek.deliverance.model.AbstractModel;
+import io.teknek.deliverance.safetensors.LoraLayerDelta;
+import io.teknek.deliverance.tensor.AbstractTensor;
+import io.teknek.deliverance.tensor.TensorShape;
+import io.teknek.deliverance.tensor.operations.TensorOperations;
+
+/**
+ * Applies one resolved LoRA delta to a projection's output: {@code output += scale * ((input @
+ * loraA^T) @ loraB^T)}, computed as two small matmuls plus an accumulate -- see step 4 plan
+ * Section 1 item 2.
+ *
+ * <p>{@code input} is whatever activation tensor the base projection itself already consumes at
+ * that hook site (e.g. {@code input}/{@code lnemb} for q/k/v/gate/up, {@code vq}/{@code bufq} for
+ * o_proj/down_proj) -- callers do not need to pre-convert it. Every real hook site's activation
+ * arrives already quantized to {@code model.getWorkingQType()} (either because
+ * {@code TransformerBlock} quantizes the block's hidden state before calling
+ * attention/feed-forward, or because the projection quantizes its own local input just before the
+ * base matmul), which the underlying SIMD/native matmul kernels only pair with a narrow, specific
+ * set of weight-side dtypes (e.g. a native {@code BF16} activation only pairs with a {@code BF16}
+ * or {@code Q4} weight-side operand, never dense {@code F32}) -- confirmed the hard way, via
+ * {@code LoraHotSwapIntegrationTest} throwing {@code UnsupportedOperationException: BF16 F32}
+ * against a real model. See step 4 plan Section 11 item 9 (revised) for the full story, including
+ * why an earlier design that fed a hand-picked *dense* tensor into each hook site instead was
+ * wrong in the opposite direction.</p>
+ *
+ * <p>To keep {@code loraA}/{@code scaledLoraB} at one precision-preserving dense dtype
+ * ({@code ResolvedLoraAdapter} resolves them to {@code model.getWorkingDType()}) regardless of
+ * what dtype the activation happens to arrive in, this dequantizes {@code input} to match
+ * {@code loraA}'s dtype first -- a no-op copy-avoidance when it's already a match (the common case
+ * once {@code workingQType == workingDType}, e.g. an explicit dense-working-memory config).</p>
+ *
+ * <p>Called once per targeted projection per {@code forward()} call, unchunked -- matching how the
+ * existing bias-accumulate calls this mirrors are themselves unchunked, not the projection's own
+ * chunked {@code VectorMath.pchunk} convention.</p>
+ */
+final class LoraDeltaApplier {
+
+    private LoraDeltaApplier() {
+    }
+
+    static void apply(AbstractModel model, AbstractTensor output, AbstractTensor input, LoraLayerDelta delta) {
+        int outFeatures = output.shape().last();
+        TensorOperations tensorOps = model.primaryTensorOperations();
+        AbstractTensor denseInput = toDType(model, input, delta.loraA().dType());
+        int batchSize = denseInput.shape().first();
+        int inFeatures = denseInput.shape().last();
+        try (AbstractTensor rankResult = model.getTensorAllocator()
+                .getDirty(model.getWorkingDType(), TensorShape.of(batchSize, delta.rank()));
+                AbstractTensor deltaResult = model.getTensorAllocator()
+                        .getDirty(model.getWorkingDType(), TensorShape.of(batchSize, outFeatures))) {
+            tensorOps.dotProductChunk(rankResult, denseInput, delta.loraA(), 0, inFeatures, 0, delta.rank());
+            tensorOps.dotProductChunk(deltaResult, rankResult, delta.scaledLoraB(), 0, delta.rank(), 0, outFeatures);
+            tensorOps.accumulate(output, deltaResult, 0, outFeatures);
+        } finally {
+            if (denseInput != input) {
+                denseInput.close();
+            }
+        }
+    }
+
+    /**
+     * Returns {@code t} unchanged if it's already {@code target}, otherwise a freshly pooled
+     * {@code target}-dtype copy -- generic element-by-element conversion via {@code get}/{@code
+     * set} (every {@code AbstractTensor} dequantizes on read regardless of its own backing dtype),
+     * the same technique {@code LoraTensorMath}/{@code MergingWeightLoader} already use to convert
+     * an adapter's on-disk dtype to a base model's dtype. Callers must close the result only when
+     * it isn't {@code t} itself -- see the {@code finally} block in {@link #apply}.
+     */
+    private static AbstractTensor toDType(AbstractModel model, AbstractTensor t, io.teknek.deliverance.DType target) {
+        if (t.dType() == target) {
+            return t;
+        }
+        AbstractTensor converted = model.getTensorAllocator().getDirty(target, t.shape());
+        int rows = t.shape().first();
+        int cols = t.shape().last();
+        for (int row = 0; row < rows; row++) {
+            for (int col = 0; col < cols; col++) {
+                converted.set(t.get(row, col), row, col);
+            }
+        }
+        return converted;
+    }
+}

--- a/core/src/main/java/io/teknek/deliverance/generator/MLPBlock.java
+++ b/core/src/main/java/io/teknek/deliverance/generator/MLPBlock.java
@@ -37,6 +37,16 @@ public class MLPBlock implements FeedForward {
     private final ConfigurableTensorProvider configurableTensorProvider;
     private final String tensorParallelCollectiveKey;
 
+    /**
+     * Base tensor names for this layer's gate/up/down projections (e.g.
+     * {@code "model.layers.3.mlp.gate_proj.weight"}), used to look up an active LoRA adapter's
+     * delta for this layer via {@link AbstractModel#activeLoraDeltaFor(String)}. {@code null} for
+     * model families that haven't opted into LoRA runtime hot-swap -- see step 4 plan Section 6.
+     */
+    private final String gateWeightName;
+    private final String upWeightName;
+    private final String downWeightName;
+
     public MLPBlock(AbstractModel model, ActivationFunction.Type activationFunction, AbstractTensor fullyConnectedWeights,
             AbstractTensor projectionWeights, AbstractTensor upProjectionWeights, ConfigurableTensorProvider configurableTensorProvider) {
         this(model, activationFunction, fullyConnectedWeights, projectionWeights, upProjectionWeights,
@@ -48,6 +58,24 @@ public class MLPBlock implements FeedForward {
             ConfigurableTensorProvider configurableTensorProvider, String tensorParallelCollectiveKey) {
         this(model, activationFunction, Optional.empty(), fullyConnectedWeights,
                 Optional.empty(), projectionWeights, upProjectionWeights, configurableTensorProvider, tensorParallelCollectiveKey);
+    }
+
+    /** Variant carrying base tensor names for LoRA runtime hot-swap, no tensor-parallel collective key. */
+    public MLPBlock(AbstractModel model, ActivationFunction.Type activationFunction, AbstractTensor fullyConnectedWeights,
+            AbstractTensor projectionWeights, AbstractTensor upProjectionWeights, ConfigurableTensorProvider configurableTensorProvider,
+            String gateWeightName, String upWeightName, String downWeightName) {
+        this(model, activationFunction, Optional.empty(), fullyConnectedWeights,
+                Optional.empty(), projectionWeights, upProjectionWeights, configurableTensorProvider, null,
+                gateWeightName, upWeightName, downWeightName);
+    }
+
+    /** Variant carrying base tensor names for LoRA runtime hot-swap, with a tensor-parallel collective key. */
+    public MLPBlock(AbstractModel model, ActivationFunction.Type activationFunction, AbstractTensor fullyConnectedWeights,
+            AbstractTensor projectionWeights, AbstractTensor upProjectionWeights, ConfigurableTensorProvider configurableTensorProvider,
+            String tensorParallelCollectiveKey, String gateWeightName, String upWeightName, String downWeightName) {
+        this(model, activationFunction, Optional.empty(), fullyConnectedWeights,
+                Optional.empty(), projectionWeights, upProjectionWeights, configurableTensorProvider, tensorParallelCollectiveKey,
+                gateWeightName, upWeightName, downWeightName);
     }
 
     public MLPBlock(
@@ -85,6 +113,25 @@ public class MLPBlock implements FeedForward {
             ConfigurableTensorProvider configurableTensorProvider,
             String tensorParallelCollectiveKey
     ) {
+        this(model, activationFunction, fullyConnectedBias, fullyConnectedWeights, projectionBias, projectionWeights,
+                upProjectionWeights, configurableTensorProvider, tensorParallelCollectiveKey, null, null, null);
+    }
+
+    /** Canonical constructor, carrying base tensor names for LoRA runtime hot-swap -- see step 4 plan Section 4.2. */
+    public MLPBlock(
+            AbstractModel model,
+            ActivationFunction.Type activationFunction,
+            Optional<AbstractTensor> fullyConnectedBias,
+            AbstractTensor fullyConnectedWeights,
+            Optional<AbstractTensor> projectionBias,
+            AbstractTensor projectionWeights,
+            AbstractTensor upProjectionWeights,
+            ConfigurableTensorProvider configurableTensorProvider,
+            String tensorParallelCollectiveKey,
+            String gateWeightName,
+            String upWeightName,
+            String downWeightName
+    ) {
         this.model = model;
         this.activationFunction = activationFunction;
         this.fullyConnectedBias = fullyConnectedBias;
@@ -96,6 +143,9 @@ public class MLPBlock implements FeedForward {
         this.batchWeights = new AbstractTensor[] { fullyConnectedWeights, upProjectionWeights };
         this.configurableTensorProvider = configurableTensorProvider;
         this.tensorParallelCollectiveKey = tensorParallelCollectiveKey;
+        this.gateWeightName = gateWeightName;
+        this.upWeightName = upWeightName;
+        this.downWeightName = downWeightName;
 
         configurableTensorProvider.get().registerModelTensor(fullyConnectedWeights);
         if (upProjectionWeights != null) {
@@ -118,6 +168,15 @@ public class MLPBlock implements FeedForward {
         if (usesLocalTensorParallelShard(hiddenLength)) {
             if (tensorParallelCollectiveKey == null) {
                 throw new IllegalStateException("Tensor-parallel MLP requires a collective key");
+            }
+            // Defense in depth: AbstractModel.setActiveAdapter already refuses to activate an adapter under
+            // tensor-parallel (so activeLoraDeltaFor below would return empty regardless), but this branch is a
+            // completely separate forward-pass code path this hook is never wired into -- a future refactor could
+            // otherwise silently reintroduce LoRA-under-TP. See step 4 plan Section 1 item 5 / Section 4.2.
+            if (model.activeLoraDeltaFor(gateWeightName).isPresent() || model.activeLoraDeltaFor(upWeightName).isPresent()
+                    || model.activeLoraDeltaFor(downWeightName).isPresent()) {
+                throw new UnsupportedOperationException(
+                        "LoRA runtime hot-swap does not support tensor-parallel inference -- see step 4 plan Section 7");
             }
             AbstractTensor reduced;
             try (Timer.Context ignoredTp = InferenceProfiler.timer(model.getMetricRegistry(), "mlpblock.tensor_parallel_forward").time()) {
@@ -165,6 +224,12 @@ public class MLPBlock implements FeedForward {
             fullyConnectedBias.ifPresent(
                     bias -> configurableTensorProvider.get().accumulate(buf, bias, 0, hiddenLength)
             );
+            model.activeLoraDeltaFor(gateWeightName).ifPresent(
+                    delta -> LoraDeltaApplier.apply(model, buf, lnemb, delta));
+            if (upProjectionWeights != null) {
+                model.activeLoraDeltaFor(upWeightName).ifPresent(
+                        delta -> LoraDeltaApplier.apply(model, buf2, lnemb, delta));
+            }
 
             if (upProjectionWeights != null) {
                 model.getMetricRegistry().counter("mlpblock.tensorplan.fused_activation_multiply").inc();
@@ -213,6 +278,9 @@ public class MLPBlock implements FeedForward {
                 tensorReducer.ifPresent(func -> func.accept(Collections.singletonList(result)));
 
                 projectionBias.ifPresent(bias -> configurableTensorProvider.get().accumulate(result, bias, 0, model.getConfig().embeddingLength));
+                // bufq is whatever the base down_proj matmul itself consumes; LoraDeltaApplier dequantizes it to
+                // match loraA's dtype internally -- see step 4 plan Section 11 item 9 (revised).
+                model.activeLoraDeltaFor(downWeightName).ifPresent(delta -> LoraDeltaApplier.apply(model, result, bufq, delta));
                 return result;
             }
         }

--- a/core/src/main/java/io/teknek/deliverance/generator/Qwen3CausalSelfAttention.java
+++ b/core/src/main/java/io/teknek/deliverance/generator/Qwen3CausalSelfAttention.java
@@ -28,8 +28,29 @@ public class Qwen3CausalSelfAttention extends CausalSelfAttention {
             ConfigurableTensorProvider configurableTensorProvider,
             MetricRegistry metricRegistry
     ) {
+        this(model, layerIndex, queryAttnWeights, keyAttnWeights, valueAttnWeights, outputProjectionWeights,
+                qNormWeights, kNormWeights, configurableTensorProvider, metricRegistry, null, null, null, null);
+    }
+
+    /** Variant carrying base tensor names for LoRA runtime hot-swap -- see step 4 plan Section 4.1. */
+    public Qwen3CausalSelfAttention(
+            AbstractModel model,
+            int layerIndex,
+            AbstractTensor queryAttnWeights,
+            AbstractTensor keyAttnWeights,
+            AbstractTensor valueAttnWeights,
+            AbstractTensor outputProjectionWeights,
+            AbstractTensor qNormWeights,
+            AbstractTensor kNormWeights,
+            ConfigurableTensorProvider configurableTensorProvider,
+            MetricRegistry metricRegistry,
+            String queryWeightName,
+            String keyWeightName,
+            String valueWeightName,
+            String outputWeightName
+    ) {
         super(model, layerIndex, queryAttnWeights, keyAttnWeights, valueAttnWeights, outputProjectionWeights,
-                configurableTensorProvider, metricRegistry);
+                configurableTensorProvider, metricRegistry, queryWeightName, keyWeightName, valueWeightName, outputWeightName);
         this.model = model;
         this.qNormWeights = qNormWeights;
         this.kNormWeights = kNormWeights;

--- a/core/src/main/java/io/teknek/deliverance/model/AbstractModel.java
+++ b/core/src/main/java/io/teknek/deliverance/model/AbstractModel.java
@@ -8,7 +8,9 @@ import com.google.common.primitives.Ints;
 import java.nio.FloatBuffer;
 import java.util.*;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 
@@ -34,7 +36,11 @@ import io.teknek.deliverance.model.tensorparallel.TensorParallelCollectives;
 import io.teknek.deliverance.model.tensorparallel.TensorParallelContext;
 import io.teknek.deliverance.model.tensorparallel.TensorParallelPlanner;
 import io.teknek.deliverance.safetensors.Config;
+import io.teknek.deliverance.safetensors.LoraAdapter;
+import io.teknek.deliverance.safetensors.LoraLayerDelta;
+import io.teknek.deliverance.safetensors.ResolvedLoraAdapter;
 import io.teknek.deliverance.safetensors.WeightLoader;
+import io.teknek.deliverance.safetensors.fetch.LoraAdapterModelFetcher;
 import io.teknek.deliverance.safetensors.prompt.PromptContext;
 import io.teknek.deliverance.safetensors.prompt.PromptSupport;
 import io.teknek.deliverance.tensor.*;
@@ -431,6 +437,98 @@ public abstract class AbstractModel implements Generator, Classifier {
         generationDebugHook.accept(event);
     }
 
+    private final ConcurrentHashMap<String, ResolvedLoraAdapter> registeredLoraAdapters = new ConcurrentHashMap<>();
+    private final AtomicReference<ResolvedLoraAdapter> activeLoraAdapter = new AtomicReference<>();
+    private final AtomicReference<String> activeLoraAdapterId = new AtomicReference<>();
+
+    /**
+     * Whether this model family supports LoRA runtime hot-swap ({@link #registerLoraAdapter}/
+     * {@link #setActiveAdapter}).
+     *
+     * <p>Opt-in, not opt-out: defaults to {@code false}, matching {@link WeightLoader}'s own
+     * "must opt in by overriding" convention for operations that aren't safe/meaningful
+     * everywhere. Families whose {@code loadTransformerBlockWeights()} threads real per-layer base
+     * tensor names through plain {@code CausalSelfAttention}/{@code MLPBlock} construction may
+     * override this to {@code true}. Families with MoE-routed feed-forward layers (one base tensor
+     * name per expert, not per layer) or independent, non-shared forward-pass classes must not --
+     * a LoRA delta silently applied to only part of a targeted module's projections would be a
+     * confusing, silently-partial result. See step 4 plan Section 6.</p>
+     */
+    protected boolean supportsLoraHotSwap() {
+        return false;
+    }
+
+    /**
+     * Registers a LoRA adapter for runtime hot-swap under {@code adapterId}, without activating
+     * it. Call {@link #setActiveAdapter(String)} to actually apply it during generation.
+     */
+    public void registerLoraAdapter(String adapterId, LoraAdapter adapter) {
+        if (!supportsLoraHotSwap()) {
+            throw new UnsupportedOperationException(getClass().getSimpleName()
+                    + " does not support LoRA runtime hot-swap -- see step 4 plan Section 6");
+        }
+        registeredLoraAdapters.put(adapterId, new ResolvedLoraAdapter(adapter, getWorkingDType()));
+    }
+
+    public void registerLoraAdapter(String adapterId, LoraAdapterModelFetcher fetcher) {
+        registerLoraAdapter(adapterId, LoraAdapter.fromPretrained(fetcher, metricRegistry));
+    }
+
+    /** Unregisters and closes a previously-registered adapter. It must not be the active adapter. */
+    public void unregisterLoraAdapter(String adapterId) {
+        if (activeLoraAdapter.get() == registeredLoraAdapters.get(adapterId)) {
+            throw new IllegalStateException("Cannot unregister the currently active LoRA adapter \""
+                    + adapterId + "\" -- call clearActiveAdapter() first");
+        }
+        ResolvedLoraAdapter removed = registeredLoraAdapters.remove(adapterId);
+        if (removed != null) {
+            removed.close();
+        }
+    }
+
+    /** Activates a previously-registered LoRA adapter; every subsequent forward pass applies its deltas. */
+    public void setActiveAdapter(String adapterId) {
+        if (tensorParallelContext.enabled()) {
+            throw new UnsupportedOperationException(
+                    "LoRA runtime hot-swap does not support tensor-parallel inference -- see step 4 plan Section 7");
+        }
+        ResolvedLoraAdapter resolved = registeredLoraAdapters.get(adapterId);
+        if (resolved == null) {
+            throw new IllegalArgumentException("No LoRA adapter registered under id \"" + adapterId + "\"");
+        }
+        activeLoraAdapter.set(resolved);
+        activeLoraAdapterId.set(adapterId);
+    }
+
+    /** Deactivates the currently active LoRA adapter, if any, restoring plain base-model behavior. */
+    public void clearActiveAdapter() {
+        activeLoraAdapter.set(null);
+        activeLoraAdapterId.set(null);
+    }
+
+    /**
+     * Returns the currently active LoRA adapter's registered id, or empty if none is active.
+     *
+     * <p>Used to scope the local prefix cache per active adapter (see {@link
+     * io.teknek.deliverance.model.LocalGenerationBackend}) -- KV state computed under one adapter
+     * (or none) must never be reused for a request running under a different adapter, even when
+     * the prompt tokens are byte-identical, or a cache hit would silently apply the wrong (or no)
+     * adapter's effect to the cached prefix. See step 4 plan Section 11 item 12.</p>
+     */
+    public Optional<String> activeLoraAdapterId() {
+        return Optional.ofNullable(activeLoraAdapterId.get());
+    }
+
+    /**
+     * Returns the active adapter's resolved delta for {@code baseTensorName}, or empty if no
+     * adapter is active or the active adapter doesn't target that tensor. Called once per targeted
+     * projection per {@code forward()} call by {@code CausalSelfAttention}/{@code MLPBlock}.
+     */
+    public Optional<LoraLayerDelta> activeLoraDeltaFor(String baseTensorName) {
+        ResolvedLoraAdapter active = activeLoraAdapter.get();
+        return active == null ? Optional.empty() : active.deltaFor(baseTensorName);
+    }
+
     /**
      * Forces the model's disk-backed KV page cleanup pass to run immediately.
      *
@@ -479,6 +577,10 @@ public abstract class AbstractModel implements Generator, Classifier {
 
     @Override
     public void close() {
+        registeredLoraAdapters.values().forEach(ResolvedLoraAdapter::close);
+        registeredLoraAdapters.clear();
+        activeLoraAdapter.set(null);
+        activeLoraAdapterId.set(null);
         if (gossipParallelMembership != null) {
             gossipParallelMembership.close();
             gossipParallelMembership = null;
@@ -491,6 +593,11 @@ public abstract class AbstractModel implements Generator, Classifier {
             }
         }
         kvBufferCache.close();
+        try {
+            weights.close();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public Optional<GossipParallelMembership> gossipParallelMembership() {

--- a/core/src/main/java/io/teknek/deliverance/model/CausalLanguageModel.java
+++ b/core/src/main/java/io/teknek/deliverance/model/CausalLanguageModel.java
@@ -3,6 +3,8 @@ package io.teknek.deliverance.model;
 import io.teknek.deliverance.generator.Generator;
 import io.teknek.deliverance.grace.PreTrainedTokenizer;
 import io.teknek.deliverance.safetensors.Config;
+import io.teknek.deliverance.safetensors.LoraAdapter;
+import io.teknek.deliverance.safetensors.fetch.LoraAdapterModelFetcher;
 import io.teknek.deliverance.safetensors.prompt.PromptSupport;
 import io.teknek.deliverance.toolcallparser.ToolCallParser;
 
@@ -66,4 +68,27 @@ public interface CausalLanguageModel extends Generator {
      * Returns the parser used to interpret generated tool-call text for this model family.
      */
     ToolCallParser getToolCallParser();
+
+    /**
+     * Registers a LoRA adapter for runtime hot-swap under {@code adapterId}, without activating
+     * it. Call {@link #setActiveAdapter(String)} to actually apply it during generation.
+     *
+     * <p>Only supported by local, non-tensor-parallel backends over an opted-in model family --
+     * see the step 4 plan (LoRA runtime hot-swap), Sections 6 and 7. Registration, activation, and
+     * clearing are equally not thread-safe against concurrent {@link #generate} calls and must be
+     * externally serialized by the caller, exactly like {@code generate} itself.</p>
+     */
+    void registerLoraAdapter(String adapterId, LoraAdapter adapter);
+
+    /** Convenience overload that fetches and loads the adapter before registering it. */
+    void registerLoraAdapter(String adapterId, LoraAdapterModelFetcher fetcher);
+
+    /** Unregisters and closes a previously-registered adapter. It must not be the active adapter. */
+    void unregisterLoraAdapter(String adapterId);
+
+    /** Activates a previously-registered LoRA adapter; every subsequent forward pass applies its deltas. */
+    void setActiveAdapter(String adapterId);
+
+    /** Deactivates the currently active LoRA adapter, if any, restoring plain base-model behavior. */
+    void clearActiveAdapter();
 }

--- a/core/src/main/java/io/teknek/deliverance/model/DefaultCausalLanguageModel.java
+++ b/core/src/main/java/io/teknek/deliverance/model/DefaultCausalLanguageModel.java
@@ -4,6 +4,8 @@ import io.teknek.deliverance.generator.GeneratorParameters;
 import io.teknek.deliverance.generator.Response;
 import io.teknek.deliverance.grace.PreTrainedTokenizer;
 import io.teknek.deliverance.safetensors.Config;
+import io.teknek.deliverance.safetensors.LoraAdapter;
+import io.teknek.deliverance.safetensors.fetch.LoraAdapterModelFetcher;
 import io.teknek.deliverance.safetensors.prompt.PromptContext;
 import io.teknek.deliverance.safetensors.prompt.PromptSupport;
 import io.teknek.deliverance.toolcallparser.ToolCallParser;
@@ -82,6 +84,39 @@ public final class DefaultCausalLanguageModel implements CausalLanguageModel {
     @Override
     public ToolCallParser getToolCallParser() {
         return coordinatorModel.getToolCallParser();
+    }
+
+    /**
+     * Delegates to {@link #coordinatorModel} directly rather than checking {@code backend
+     * instanceof LocalGenerationBackend} first -- {@code coordinatorModel}'s own
+     * {@code tensorParallelContext} correctly reflects this rank's TP state regardless of which
+     * backend wraps it, so {@code AbstractModel.setActiveAdapter}'s existing TP guard already
+     * enforces the step 4 plan's Section 7 non-goal at this layer too. See step 4 plan Section
+     * 3.1's "implementation-time item to verify" for why either placement is correct.
+     */
+    @Override
+    public void registerLoraAdapter(String adapterId, LoraAdapter adapter) {
+        coordinatorModel.registerLoraAdapter(adapterId, adapter);
+    }
+
+    @Override
+    public void registerLoraAdapter(String adapterId, LoraAdapterModelFetcher fetcher) {
+        coordinatorModel.registerLoraAdapter(adapterId, fetcher);
+    }
+
+    @Override
+    public void unregisterLoraAdapter(String adapterId) {
+        coordinatorModel.unregisterLoraAdapter(adapterId);
+    }
+
+    @Override
+    public void setActiveAdapter(String adapterId) {
+        coordinatorModel.setActiveAdapter(adapterId);
+    }
+
+    @Override
+    public void clearActiveAdapter() {
+        coordinatorModel.clearActiveAdapter();
     }
 
     /**

--- a/core/src/main/java/io/teknek/deliverance/model/LocalGenerationBackend.java
+++ b/core/src/main/java/io/teknek/deliverance/model/LocalGenerationBackend.java
@@ -4,6 +4,7 @@ import io.teknek.deliverance.generator.GeneratorParameters;
 import io.teknek.deliverance.tensor.AbstractTensor;
 import io.teknek.deliverance.tensor.KvBufferCache;
 
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -35,14 +36,16 @@ public final class LocalGenerationBackend implements GenerationBackend {
     private final class LocalGenerationSession implements GenerationSession {
         private final int[] promptTokens;
         private final GeneratorParameters parameters;
+        private final Optional<String> effectiveCacheSalt;
         private final KvBufferCache.KvBuffer kvBuffer;
         private final int prefixLength;
 
         private LocalGenerationSession(int[] promptTokens, GeneratorParameters parameters) {
             this.promptTokens = promptTokens;
             this.parameters = parameters;
+            this.effectiveCacheSalt = withActiveAdapterScope(parameters.cacheSalt);
             this.kvBuffer = model.kvBufferCache.getEphemeralKvBuffer();
-            KvBufferCache.PrefixEntry prefixHit = model.kvBufferCache.lookupPrefix(promptTokens, parameters.cacheSalt);
+            KvBufferCache.PrefixEntry prefixHit = model.kvBufferCache.lookupPrefix(promptTokens, effectiveCacheSalt);
             if (prefixHit == null) {
                 this.prefixLength = 0;
             } else {
@@ -82,7 +85,7 @@ public final class LocalGenerationBackend implements GenerationBackend {
             AbstractTensor last;
             if (cursor.hasTokensToProcess()) {
                 last = model.batchForward(cursor.tokensToProcess(), cursor.startPosition(), kvBuffer);
-                model.kvBufferCache.storePrefix(promptTokens, kvBuffer, parameters.cacheSalt);
+                model.kvBufferCache.storePrefix(promptTokens, kvBuffer, effectiveCacheSalt);
             } else {
                 last = model.forward(cursor.replayToken(), cursor.replayPosition(), kvBuffer);
             }
@@ -113,5 +116,20 @@ public final class LocalGenerationBackend implements GenerationBackend {
         public void close() {
             kvBuffer.close();
         }
+    }
+
+    /**
+     * Folds the currently active LoRA adapter's id (if any) into the caller-supplied cache salt,
+     * so the local prefix cache never reuses KV state computed under a different active adapter
+     * (or no adapter) for byte-identical prompt tokens -- see step 4 plan Section 11 item 12. A
+     * request with no active adapter gets the caller's salt back unchanged, so models that never
+     * use hot-swap see no behavior change at all.
+     */
+    private Optional<String> withActiveAdapterScope(Optional<String> callerSalt) {
+        Optional<String> adapterId = model.activeLoraAdapterId();
+        if (adapterId.isEmpty()) {
+            return callerSalt;
+        }
+        return Optional.of("lora:" + adapterId.get() + "|" + callerSalt.orElse(""));
     }
 }

--- a/core/src/main/java/io/teknek/deliverance/model/gemma2/Gemma2Model.java
+++ b/core/src/main/java/io/teknek/deliverance/model/gemma2/Gemma2Model.java
@@ -71,24 +71,33 @@ public class Gemma2Model extends LlamaModel {
         IntStream.range(0, config.numberOfLayers).parallel().forEach(i -> {
             String base = "model.layers." + i + ".";
             String prefix = base + "self_attn.";
+            String qName = prefix + "q_proj.weight";
+            String kName = prefix + "k_proj.weight";
+            String vName = prefix + "v_proj.weight";
+            String oName = prefix + "o_proj.weight";
             CausalSelfAttention attention = new CausalSelfAttention(this, i,
-                    quantize(tensorParallelWeights.load(prefix + "q_proj.weight"), qType),
-                    quantize(tensorParallelWeights.load(prefix + "k_proj.weight"), qType),
-                    quantize(tensorParallelWeights.load(prefix + "v_proj.weight"), qType),
-                    quantize(tensorParallelWeights.load(prefix + "o_proj.weight"), qType),
+                    quantize(tensorParallelWeights.load(qName), qType),
+                    quantize(tensorParallelWeights.load(kName), qType),
+                    quantize(tensorParallelWeights.load(vName), qType),
+                    quantize(tensorParallelWeights.load(oName), qType),
                     configurableTensorProvider,
-                    metricRegistry
+                    metricRegistry,
+                    qName, kName, vName, oName
             );
 
             prefix = base + "mlp.";
+            String gateName = prefix + "gate_proj.weight";
+            String downName = prefix + "down_proj.weight";
+            String upName = prefix + "up_proj.weight";
             MLPBlock mlp = new MLPBlock(
                     this,
                     config.activationFunction,
-                    quantize(tensorParallelWeights.load(prefix + "gate_proj.weight"), qType), // w1
-                    quantize(tensorParallelWeights.load(prefix + "down_proj.weight"), qType), // w2
-                    quantize(tensorParallelWeights.load(prefix + "up_proj.weight"), qType), // w3,
+                    quantize(tensorParallelWeights.load(gateName), qType), // w1
+                    quantize(tensorParallelWeights.load(downName), qType), // w2
+                    quantize(tensorParallelWeights.load(upName), qType), // w3,
                     configurableTensorProvider,
-                    "layer." + i + ".mlp.down_proj"
+                    "layer." + i + ".mlp.down_proj",
+                    gateName, upName, downName
             );
 
             transformerBlocks[i] = new TransformerBlock(this, i,

--- a/core/src/main/java/io/teknek/deliverance/model/gemma3/Gemma3Model.java
+++ b/core/src/main/java/io/teknek/deliverance/model/gemma3/Gemma3Model.java
@@ -63,23 +63,32 @@ public class Gemma3Model extends LlamaModel {
         IntStream.range(0, config.numberOfLayers).parallel().forEach(i -> {
             String base = "model.layers." + i + ".";
             String prefix = base + "self_attn.";
+            String qName = prefix + "q_proj.weight";
+            String kName = prefix + "k_proj.weight";
+            String vName = prefix + "v_proj.weight";
+            String oName = prefix + "o_proj.weight";
             CausalSelfAttention attention = new CausalSelfAttention(this, i,
-                    quantize(weights.load(prefix + "q_proj.weight"), qType),
-                    quantize(weights.load(prefix + "k_proj.weight"), qType),
-                    quantize(weights.load(prefix + "v_proj.weight"), qType),
-                    quantize(weights.load(prefix + "o_proj.weight"), qType),
+                    quantize(weights.load(qName), qType),
+                    quantize(weights.load(kName), qType),
+                    quantize(weights.load(vName), qType),
+                    quantize(weights.load(oName), qType),
                     configurableTensorProvider,
-                    metricRegistry
+                    metricRegistry,
+                    qName, kName, vName, oName
             );
 
             prefix = base + "mlp.";
+            String gateName = prefix + "gate_proj.weight";
+            String downName = prefix + "down_proj.weight";
+            String upName = prefix + "up_proj.weight";
             MLPBlock mlp = new MLPBlock(
                     this,
                     config.activationFunction,
-                    quantize(weights.load(prefix + "gate_proj.weight"), qType), // w1
-                    quantize(weights.load(prefix + "down_proj.weight"), qType), // w2
-                    quantize(weights.load(prefix + "up_proj.weight"), qType), // w3,
-                    configurableTensorProvider
+                    quantize(weights.load(gateName), qType), // w1
+                    quantize(weights.load(downName), qType), // w2
+                    quantize(weights.load(upName), qType), // w3,
+                    configurableTensorProvider,
+                    gateName, upName, downName
             );
 
             transformerBlocks[i] = new TransformerBlock(this, i,

--- a/core/src/main/java/io/teknek/deliverance/model/gemma4/Gemma4Model.java
+++ b/core/src/main/java/io/teknek/deliverance/model/gemma4/Gemma4Model.java
@@ -34,6 +34,17 @@ public class Gemma4Model extends LlamaModel {
     private volatile AbstractTensor perLayerProjectionNormWeights;
     private volatile AbstractTensor embedTokenWeights;
 
+    /**
+     * Not supported: {@code loadTransformerBlockWeights()} uses the independent
+     * {@code Gemma4CausalSelfAttention}/{@code VariableMLPBlock} classes, which share no code with
+     * {@code CausalSelfAttention}/{@code MLPBlock} and have no LoRA hook wired in. Overrides
+     * {@code LlamaModel}'s inherited {@code true} back to {@code false}. See step 4 plan Section 6.
+     */
+    @Override
+    protected boolean supportsLoraHotSwap() {
+        return false;
+    }
+
     public record SharedKeyValues(AbstractTensor key, AbstractTensor value) implements AutoCloseable {
         @Override
         public void close() {

--- a/core/src/main/java/io/teknek/deliverance/model/llama/LlamaModel.java
+++ b/core/src/main/java/io/teknek/deliverance/model/llama/LlamaModel.java
@@ -78,6 +78,17 @@ public class LlamaModel extends AbstractModel {
         };
     }
 
+    /**
+     * Supports LoRA runtime hot-swap: {@code loadTransformerBlockWeights()} threads real per-layer
+     * base tensor names through plain {@code CausalSelfAttention}/{@code MLPBlock} construction.
+     * Inherited by every {@code LlamaModel} subclass unless overridden back to {@code false} (see
+     * {@code Gemma4Model}, {@code Qwen3MoeModel}, {@code MixtralModel}) -- step 4 plan Section 6.
+     */
+    @Override
+    protected boolean supportsLoraHotSwap() {
+        return true;
+    }
+
     @Override
     protected TransformerBlock[] loadTransformerBlockWeights() {
         DType qType = modelQType.orElse(this.modelDType);
@@ -86,25 +97,34 @@ public class LlamaModel extends AbstractModel {
             int relativeLayer = i;
             String base = "model.layers." + i + ".";
             String prefix = base + "self_attn.";
+            String qName = prefix + "q_proj.weight";
+            String kName = prefix + "k_proj.weight";
+            String vName = prefix + "v_proj.weight";
+            String oName = prefix + "o_proj.weight";
             CausalSelfAttention attention = new CausalSelfAttention(
                     this,
                     relativeLayer,
-                    quantize(weights.load(prefix + "q_proj.weight"), qType),
-                    quantize(weights.load(prefix + "k_proj.weight"), qType),
-                    quantize(weights.load(prefix + "v_proj.weight"), qType),
-                    quantize(weights.load(prefix + "o_proj.weight"), qType),
+                    quantize(weights.load(qName), qType),
+                    quantize(weights.load(kName), qType),
+                    quantize(weights.load(vName), qType),
+                    quantize(weights.load(oName), qType),
                     configurableTensorProvider,
-                    metricRegistry
+                    metricRegistry,
+                    qName, kName, vName, oName
             );
 
             prefix = base + "mlp.";
+            String gateName = prefix + "gate_proj.weight";
+            String downName = prefix + "down_proj.weight";
+            String upName = prefix + "up_proj.weight";
             MLPBlock mlp = new MLPBlock(
                     this,
                     config.activationFunction,
-                    quantize(weights.load(prefix + "gate_proj.weight"), qType), // w1
-                    quantize(weights.load(prefix + "down_proj.weight"), qType), // w2
-                    quantize(weights.load(prefix + "up_proj.weight"), qType),
-                    configurableTensorProvider
+                    quantize(weights.load(gateName), qType), // w1
+                    quantize(weights.load(downName), qType), // w2
+                    quantize(weights.load(upName), qType),
+                    configurableTensorProvider,
+                    gateName, upName, downName
             ); // w3
 
             transformerBlocks[relativeLayer] = new TransformerBlock(

--- a/core/src/main/java/io/teknek/deliverance/model/mixtral/MixtralModel.java
+++ b/core/src/main/java/io/teknek/deliverance/model/mixtral/MixtralModel.java
@@ -35,7 +35,20 @@ public class MixtralModel extends LlamaModel {
                 metricRegistry, arrayQueueTensorAllocator, kvBufferCacheSettings, toolCallParser, pool, tensorParallelContext,
                 tensorParallelCollectives, outputHeadQuantization);
     }
-    
+
+    /**
+     * Not supported: attention uses plain {@code CausalSelfAttention} (free LoRA coverage), but the
+     * feed-forward layer routes through {@code MixtureOfExpertsBlock} (one base tensor name per
+     * expert, not per layer) -- the same MoE-routing ambiguity {@code Qwen3MoeModel}/
+     * {@code GraniteMoeHybridModel} are excluded for. Overrides {@code LlamaModel}'s inherited
+     * {@code true} back to {@code false}. See step 4 plan Section 6/Section 11 item 6 -- this gap
+     * was missed by the original family survey and found only during implementation.
+     */
+    @Override
+    protected boolean supportsLoraHotSwap() {
+        return false;
+    }
+
     @Override
     protected TransformerBlock[] loadTransformerBlockWeights() {
         MixtralConfig mixtralConfig = (MixtralConfig) config;

--- a/core/src/main/java/io/teknek/deliverance/model/qwen2/Qwen2Model.java
+++ b/core/src/main/java/io/teknek/deliverance/model/qwen2/Qwen2Model.java
@@ -69,29 +69,38 @@ public class Qwen2Model extends LlamaModel {
             int relativeLayer = i;
             String base = "model.layers." + i + ".";
             String prefix = base + "self_attn.";
+            String qName = prefix + "q_proj.weight";
+            String kName = prefix + "k_proj.weight";
+            String vName = prefix + "v_proj.weight";
+            String oName = prefix + "o_proj.weight";
             CausalSelfAttention attention = new CausalSelfAttention(
                     this,
                     relativeLayer,
                     Optional.of(quantize(weights.load(prefix + "q_proj.bias"), qType)),
                     Optional.of(quantize(weights.load(prefix + "k_proj.bias"), qType)),
                     Optional.of(quantize(weights.load(prefix + "v_proj.bias"), qType)),
-                    quantize(weights.load(prefix + "q_proj.weight"), qType),
-                    quantize(weights.load(prefix + "k_proj.weight"), qType),
-                    quantize(weights.load(prefix + "v_proj.weight"), qType),
+                    quantize(weights.load(qName), qType),
+                    quantize(weights.load(kName), qType),
+                    quantize(weights.load(vName), qType),
                     Optional.empty(),
-                    quantize(weights.load(prefix + "o_proj.weight"), qType),
+                    quantize(weights.load(oName), qType),
                     configurableTensorProvider,
-                    metricRegistry
+                    metricRegistry,
+                    qName, kName, vName, oName
             );
 
             prefix = base + "mlp.";
+            String gateName = prefix + "gate_proj.weight";
+            String downName = prefix + "down_proj.weight";
+            String upName = prefix + "up_proj.weight";
             MLPBlock mlp = new MLPBlock(
                     this,
                     config.activationFunction,
-                    quantize(weights.load(prefix + "gate_proj.weight"), qType), // w1
-                    quantize(weights.load(prefix + "down_proj.weight"), qType), // w2
-                    quantize(weights.load(prefix + "up_proj.weight"), qType),
-                    configurableTensorProvider
+                    quantize(weights.load(gateName), qType), // w1
+                    quantize(weights.load(downName), qType), // w2
+                    quantize(weights.load(upName), qType),
+                    configurableTensorProvider,
+                    gateName, upName, downName
             ); // w3
 
             transformerBlocks[relativeLayer] = new TransformerBlock(

--- a/core/src/main/java/io/teknek/deliverance/model/qwen3/Qwen3Model.java
+++ b/core/src/main/java/io/teknek/deliverance/model/qwen3/Qwen3Model.java
@@ -56,27 +56,36 @@ public class Qwen3Model extends LlamaModel {
         IntStream.range(0, config.numberOfLayers).parallel().forEach(i -> {
             String base = "model.layers." + i + ".";
             String attn = base + "self_attn.";
+            String qName = attn + "q_proj.weight";
+            String kName = attn + "k_proj.weight";
+            String vName = attn + "v_proj.weight";
+            String oName = attn + "o_proj.weight";
             Qwen3CausalSelfAttention attention = new Qwen3CausalSelfAttention(
                     this,
                     i,
-                    quantize(weights.load(attn + "q_proj.weight"), qType),
-                    quantize(weights.load(attn + "k_proj.weight"), qType),
-                    quantize(weights.load(attn + "v_proj.weight"), qType),
-                    quantize(weights.load(attn + "o_proj.weight"), qType),
+                    quantize(weights.load(qName), qType),
+                    quantize(weights.load(kName), qType),
+                    quantize(weights.load(vName), qType),
+                    quantize(weights.load(oName), qType),
                     quantize(weights.load(attn + "q_norm.weight"), qType),
                     quantize(weights.load(attn + "k_norm.weight"), qType),
                     configurableTensorProvider,
-                    metricRegistry
+                    metricRegistry,
+                    qName, kName, vName, oName
             );
 
             String mlpPrefix = base + "mlp.";
+            String gateName = mlpPrefix + "gate_proj.weight";
+            String downName = mlpPrefix + "down_proj.weight";
+            String upName = mlpPrefix + "up_proj.weight";
             MLPBlock mlp = new MLPBlock(
                     this,
                     config.activationFunction,
-                    quantize(weights.load(mlpPrefix + "gate_proj.weight"), qType),
-                    quantize(weights.load(mlpPrefix + "down_proj.weight"), qType),
-                    quantize(weights.load(mlpPrefix + "up_proj.weight"), qType),
-                    configurableTensorProvider
+                    quantize(weights.load(gateName), qType),
+                    quantize(weights.load(downName), qType),
+                    quantize(weights.load(upName), qType),
+                    configurableTensorProvider,
+                    gateName, upName, downName
             );
 
             blocks[i] = new TransformerBlock(

--- a/core/src/main/java/io/teknek/deliverance/model/qwen3/Qwen3MoeModel.java
+++ b/core/src/main/java/io/teknek/deliverance/model/qwen3/Qwen3MoeModel.java
@@ -37,6 +37,18 @@ public class Qwen3MoeModel extends Qwen3Model {
                 toolCallParser, pool, tensorParallelContext, tensorParallelCollectives, outputHeadQuantization);
     }
 
+    /**
+     * Not supported: dense layers use {@code MLPBlock} (free LoRA coverage) but sparse layers route
+     * through {@code Qwen3MoeFeedForward} (one base tensor name per expert, not per layer) -- a real
+     * adapter targeting gate/up/down would apply silently only to dense layers, a confusing
+     * partial result. Overrides {@code Qwen3Model}'s (inherited from {@code LlamaModel}) {@code
+     * true} back to {@code false}. See step 4 plan Section 6.
+     */
+    @Override
+    protected boolean supportsLoraHotSwap() {
+        return false;
+    }
+
     @Override
     protected TransformerBlock[] loadTransformerBlockWeights() {
         Qwen3MoeConfig moeConfig = (Qwen3MoeConfig) config;

--- a/core/src/test/java/io/teknek/deliverance/generator/LoraDeltaApplierTest.java
+++ b/core/src/test/java/io/teknek/deliverance/generator/LoraDeltaApplierTest.java
@@ -1,0 +1,67 @@
+package io.teknek.deliverance.generator;
+
+import io.teknek.deliverance.DType;
+import io.teknek.deliverance.model.AbstractModel;
+import io.teknek.deliverance.safetensors.LoraLayerDelta;
+import io.teknek.deliverance.tensor.AbstractTensor;
+import io.teknek.deliverance.tensor.TensorAllocator;
+import io.teknek.deliverance.tensor.TensorShape;
+import io.teknek.deliverance.tensor.impl.FloatBufferTensor;
+import io.teknek.deliverance.tensor.operations.NaiveTensorOperations;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies {@link LoraDeltaApplier}'s two-matmul-plus-accumulate math against a small
+ * hand-computed reference -- see step 4 plan Section 8's "prove the math on edge cases with a
+ * naive/reference calculation" testing convention (same one steps 1-3 used).
+ */
+public class LoraDeltaApplierTest {
+
+    @Test
+    void appliesTwoMatmulPlusAccumulateAgainstHandComputedReference() {
+        AbstractModel model = Mockito.mock(AbstractModel.class);
+        when(model.primaryTensorOperations()).thenReturn(new NaiveTensorOperations());
+        when(model.getWorkingDType()).thenReturn(DType.F32);
+        TensorAllocator allocator = Mockito.mock(TensorAllocator.class);
+        when(allocator.getDirty(Mockito.eq(DType.F32), Mockito.any(TensorShape.class)))
+                .thenAnswer(invocation -> new FloatBufferTensor((TensorShape) invocation.getArgument(1)));
+        when(model.getTensorAllocator()).thenReturn(allocator);
+
+        // input = [1, 2, 3] (batch=1, inFeatures=3)
+        try (AbstractTensor input = new FloatBufferTensor(1, 3);
+                AbstractTensor loraA = new FloatBufferTensor(2, 3); // [rank=2, inFeatures=3]
+                AbstractTensor scaledLoraB = new FloatBufferTensor(2, 2); // [outFeatures=2, rank=2]
+                AbstractTensor output = new FloatBufferTensor(1, 2)) {
+            input.set(1.0f, 0, 0);
+            input.set(2.0f, 0, 1);
+            input.set(3.0f, 0, 2);
+
+            // loraA row0 = [1,0,0], row1 = [0,1,0] -> rankResult = [1, 2]
+            loraA.set(1.0f, 0, 0);
+            loraA.set(0.0f, 0, 1);
+            loraA.set(0.0f, 0, 2);
+            loraA.set(0.0f, 1, 0);
+            loraA.set(1.0f, 1, 1);
+            loraA.set(0.0f, 1, 2);
+
+            // scaledLoraB row0 = [1,1] -> 1*1+2*1=3, row1 = [2,0] -> 1*2+2*0=2 -> deltaResult = [3, 2]
+            scaledLoraB.set(1.0f, 0, 0);
+            scaledLoraB.set(1.0f, 0, 1);
+            scaledLoraB.set(2.0f, 1, 0);
+            scaledLoraB.set(0.0f, 1, 1);
+
+            output.set(10.0f, 0, 0);
+            output.set(20.0f, 0, 1);
+
+            LoraLayerDelta delta = new LoraLayerDelta(loraA, scaledLoraB, 2);
+            LoraDeltaApplier.apply(model, output, input, delta);
+
+            assertEquals(13.0f, output.get(0, 0), 1e-6f);
+            assertEquals(22.0f, output.get(0, 1), 1e-6f);
+        }
+    }
+}

--- a/core/src/test/java/io/teknek/deliverance/integration/LoraHotSwapIntegrationTest.java
+++ b/core/src/test/java/io/teknek/deliverance/integration/LoraHotSwapIntegrationTest.java
@@ -1,0 +1,99 @@
+package io.teknek.deliverance.integration;
+
+import io.teknek.deliverance.DType;
+import io.teknek.deliverance.generator.GeneratorParameters;
+import io.teknek.deliverance.generator.Response;
+import io.teknek.deliverance.model.AbstractModel;
+import io.teknek.deliverance.model.AutoModelForCausaLm;
+import io.teknek.deliverance.model.DoNothingGenerateEvent;
+import io.teknek.deliverance.safetensors.LoraAdapter;
+import io.teknek.deliverance.safetensors.fetch.LoraAdapterModelFetcher;
+import io.teknek.deliverance.safetensors.fetch.ModelFetcher;
+import io.teknek.deliverance.safetensors.prompt.PromptSupport;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * End-to-end check for Phase 2 "runtime hot-swap" LoRA support ({@link
+ * AbstractModel#registerLoraAdapter}/{@link AbstractModel#setActiveAdapter}/{@link
+ * AbstractModel#clearActiveAdapter}), per the step 4 plan (LoRA runtime hot-swap) Section 8.
+ * Requires network access, same base/adapter pairing as {@code MergingWeightLoaderIntegrationTest}
+ * (Phase 1's equivalent test) so the two are directly comparable.
+ */
+public class LoraHotSwapIntegrationTest {
+
+    private static final String PROMPT = "Hello! Who are you and what can you help me with?";
+
+    @Test
+    public void activatingAppliesTheAdapterAndClearingRestoresBaseModelBehavior() {
+        ModelFetcher fetcher = new ModelFetcher("unsloth", "Llama-3.2-1B-Instruct");
+
+        try (AbstractModel model = AutoModelForCausaLm.newBuilder(fetcher).buildLocalTransformerModel()) {
+            String baselineA = generate(model);
+
+            model.registerLoraAdapter("bunnycore-chatml",
+                    new LoraAdapterModelFetcher("bunnycore", "Llama-3.2-1b-chatml-lora_model"));
+            model.setActiveAdapter("bunnycore-chatml");
+            String adaptedResponse = generate(model);
+            assertNotEquals(baselineA, adaptedResponse,
+                    "activating a LoRA adapter should measurably change generation");
+
+            model.clearActiveAdapter();
+            String baselineB = generate(model);
+            assertEquals(baselineA, baselineB,
+                    "clearing the active adapter must restore exact base-model behavior, not just change it again");
+        }
+    }
+
+    /**
+     * Phase 1 (merge-at-load) vs Phase 2 (runtime hot-swap) equivalence -- only expected to hold
+     * for dense working-memory types (see step 4 plan Section 1 item 6): Phase 1 computes
+     * {@code quantize(base_weight + delta)} at load time, Phase 2 computes {@code
+     * quantize(base_weight)} once and adds a separately-computed, full-precision delta to the
+     * activation after the (unquantized, since {@code withWorkingQuantType(F32)} here) base
+     * projection runs. These are different operations, not just different implementations of the
+     * same one, so this comparison is meaningless under the default (I8) working-quant
+     * configuration and must not be read as "Phase 1 and Phase 2 always agree."
+     */
+    @Test
+    public void phase1MergeAtLoadAndPhase2HotSwapAgreeUnderDenseWorkingMemory() {
+        ModelFetcher fetcher = new ModelFetcher("unsloth", "Llama-3.2-1B-Instruct");
+        LoraAdapterModelFetcher adapterFetcher = new LoraAdapterModelFetcher("bunnycore", "Llama-3.2-1b-chatml-lora_model");
+
+        String phase1Response;
+        try (AbstractModel phase1 = AutoModelForCausaLm.newBuilder(fetcher)
+                .withWorkingMemoryType(DType.F32)
+                .withWorkingQuantType(DType.F32)
+                .withLoraAdapter(adapterFetcher)
+                .buildLocalTransformerModel()) {
+            phase1Response = generate(phase1);
+        }
+
+        String phase2Response;
+        try (AbstractModel phase2 = AutoModelForCausaLm.newBuilder(fetcher)
+                .withWorkingMemoryType(DType.F32)
+                .withWorkingQuantType(DType.F32)
+                .buildLocalTransformerModel()) {
+            phase2.registerLoraAdapter("bunnycore-chatml", adapterFetcher);
+            phase2.setActiveAdapter("bunnycore-chatml");
+            phase2Response = generate(phase2);
+        }
+
+        System.out.println("[phase1 merge-at-load] " + phase1Response);
+        System.out.println("[phase2 runtime hot-swap] " + phase2Response);
+        assertEquals(phase1Response, phase2Response,
+                "Phase 1 and Phase 2 must agree under dense (F32) working memory -- see step 4 plan Section 1 item 6");
+    }
+
+    private static String generate(AbstractModel model) {
+        PromptSupport.Builder promptBuilder = model.promptSupport().orElseThrow().builder().addUserMessage(PROMPT);
+        Response response = model.generate(UUID.randomUUID(), promptBuilder.build(),
+                new GeneratorParameters().withMaxTokens(80).withTemperature(0.0f).withSeed(42),
+                new DoNothingGenerateEvent());
+        return response.responseText;
+    }
+}

--- a/core/src/test/java/io/teknek/deliverance/model/AbstractModelLoraHotSwapTest.java
+++ b/core/src/test/java/io/teknek/deliverance/model/AbstractModelLoraHotSwapTest.java
@@ -1,0 +1,200 @@
+package io.teknek.deliverance.model;
+
+import com.codahale.metrics.MetricRegistry;
+import io.teknek.deliverance.DType;
+import io.teknek.deliverance.generator.EmbedInput;
+import io.teknek.deliverance.generator.SampleOutput;
+import io.teknek.deliverance.generator.TransformerBlock;
+import io.teknek.deliverance.math.ActivationFunction;
+import io.teknek.deliverance.math.WrappedForkJoinPool;
+import io.teknek.deliverance.model.tensorparallel.StaticTensorParallelContext;
+import io.teknek.deliverance.model.tensorparallel.TensorParallelContext;
+import io.teknek.deliverance.safetensors.Config;
+import io.teknek.deliverance.safetensors.LoraAdapter;
+import io.teknek.deliverance.safetensors.LoraAdapterConfig;
+import io.teknek.deliverance.safetensors.LoraLayerDelta;
+import io.teknek.deliverance.safetensors.SafeTensorWriter;
+import io.teknek.deliverance.safetensors.WeightLoader;
+import io.teknek.deliverance.tensor.AbstractTensor;
+import io.teknek.deliverance.tensor.ArrayQueueTensorAllocator;
+import io.teknek.deliverance.tensor.KvBufferCacheSettings;
+import io.teknek.deliverance.tensor.TensorInfo;
+import io.teknek.deliverance.tensor.impl.FloatBufferTensor;
+import io.teknek.deliverance.tensor.operations.ConfigurableTensorProvider;
+import io.teknek.deliverance.tensor.operations.NaiveTensorOperations;
+import io.teknek.deliverance.toolcallparser.DefaultToolCallParser;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ForkJoinPool;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests (no network) for {@link AbstractModel}'s LoRA runtime hot-swap registry and lifecycle
+ * -- registration, activation, clearing, the tensor-parallel non-goal guard, and the
+ * {@link AbstractModel#close()} resource fix. See step 4 plan Section 8's non-goal-guard and
+ * close()-resource-test items.
+ *
+ * <p>Uses a minimal real {@link AbstractModel} subclass ({@code TinyModel}, modeled on {@code
+ * GuidedChoiceLogitsProcessorTest.TinyChoiceModel}) rather than a bare Mockito mock: {@code
+ * registerLoraAdapter}/{@code setActiveAdapter} read real instance fields ({@code
+ * tensorParallelContext}, {@code registeredLoraAdapters}) that a constructor-bypassing mock would
+ * leave {@code null}.</p>
+ */
+public class AbstractModelLoraHotSwapTest {
+
+    private static final String Q_PROJ = "model.layers.0.self_attn.q_proj.weight";
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void registerLoraAdapterThrowsWhenFamilyDoesNotSupportHotSwap() throws IOException {
+        TinyModel model = new TinyModel(false, new StaticTensorParallelContext(0, 1), new TinyWeightLoader());
+        try (LoraAdapter adapter = buildSyntheticAdapter()) {
+            assertThrows(UnsupportedOperationException.class, () -> model.registerLoraAdapter("a", adapter));
+        } finally {
+            model.close();
+        }
+    }
+
+    @Test
+    void registerSetActiveClearAndUnregisterLifecycleWorks() throws IOException {
+        TinyModel model = new TinyModel(true, new StaticTensorParallelContext(0, 1), new TinyWeightLoader());
+        try {
+            LoraAdapter adapter = buildSyntheticAdapter();
+            model.registerLoraAdapter("a", adapter);
+
+            assertTrue(model.activeLoraDeltaFor(Q_PROJ).isEmpty(), "no adapter active yet");
+
+            model.setActiveAdapter("a");
+            Optional<LoraLayerDelta> delta = model.activeLoraDeltaFor(Q_PROJ);
+            assertTrue(delta.isPresent());
+            assertTrue(model.activeLoraDeltaFor("model.layers.0.self_attn.k_proj.weight").isEmpty(),
+                    "adapter doesn't target k_proj");
+
+            assertThrows(IllegalStateException.class, () -> model.unregisterLoraAdapter("a"),
+                    "cannot unregister the currently active adapter");
+
+            model.clearActiveAdapter();
+            assertTrue(model.activeLoraDeltaFor(Q_PROJ).isEmpty(), "clearing must stop applying the delta");
+
+            model.unregisterLoraAdapter("a"); // fine now that it's no longer active
+            assertThrows(IllegalArgumentException.class, () -> model.setActiveAdapter("a"),
+                    "adapter is no longer registered");
+        } finally {
+            model.close();
+        }
+    }
+
+    @Test
+    void setActiveAdapterThrowsUnderTensorParallel() throws IOException {
+        TinyModel model = new TinyModel(true, new StaticTensorParallelContext(0, 2), new TinyWeightLoader());
+        try (LoraAdapter adapter = buildSyntheticAdapter()) {
+            model.registerLoraAdapter("a", adapter);
+            assertThrows(UnsupportedOperationException.class, () -> model.setActiveAdapter("a"));
+        } finally {
+            model.close();
+        }
+    }
+
+    @Test
+    void closeClosesRegisteredAdaptersAndTheBaseWeightLoader() throws IOException {
+        TinyWeightLoader weightLoader = new TinyWeightLoader();
+        TinyModel model = new TinyModel(true, new StaticTensorParallelContext(0, 1), weightLoader);
+        LoraAdapter adapter = Mockito.spy(buildSyntheticAdapter());
+        model.registerLoraAdapter("a", adapter);
+
+        model.close();
+
+        assertTrue(weightLoader.closed, "AbstractModel.close() must close the base WeightLoader");
+        Mockito.verify(adapter).close();
+    }
+
+    private LoraAdapter buildSyntheticAdapter() throws IOException {
+        Path adapterDir = Files.createTempDirectory(tempDir, "adapter");
+        Files.writeString(adapterDir.resolve(LoraAdapterConfig.FILE_NAME),
+                "{\"r\": 4, \"lora_alpha\": 8.0, \"target_modules\": [\"q_proj\"]}");
+        // LoraTensorNames is package-private to io.teknek.deliverance.safetensors; its documented
+        // convention ("base_model.model." + base-without-".weight" + ".lora_A/B.weight") is
+        // inlined here rather than duplicated as a public helper just for this test.
+        String withoutWeight = Q_PROJ.substring(0, Q_PROJ.length() - ".weight".length());
+        String loraAName = "base_model.model." + withoutWeight + ".lora_A.weight";
+        String loraBName = "base_model.model." + withoutWeight + ".lora_B.weight";
+        Map<String, AbstractTensor> tensors = new LinkedHashMap<>();
+        tensors.put(loraAName, new FloatBufferTensor(4, 4));
+        tensors.put(loraBName, new FloatBufferTensor(4, 4));
+        SafeTensorWriter.write(adapterDir.resolve(LoraAdapter.SAFETENSORS_FILE_NAME), Map.of(), tensors);
+        return LoraAdapter.load(adapterDir.toFile());
+    }
+
+    private static final class TinyModel extends AbstractModel {
+        // numberOfHeads=numberOfKeyValueHeads=2, embeddingLength=4 (headSize=2), hiddenLength=8:
+        // divides evenly for tensor-parallel size 2, needed by the TP-guard test.
+        private static final Config CONFIG = new Config(16, 4, 8, 2, 2, 1, 1.0e-6f,
+                10, 0, List.of(0), ActivationFunction.Type.SILU, null, Map.of());
+        private final boolean hotSwapSupported;
+
+        TinyModel(boolean hotSwapSupported, TensorParallelContext tensorParallelContext, WeightLoader weightLoader) {
+            super(InferenceType.OUTPUT_TO_TOKEN, CONFIG, weightLoader, null, DType.F32, DType.F32,
+                    Optional.empty(), new ConfigurableTensorProvider(new NaiveTensorOperations()), new MetricRegistry(),
+                    new ArrayQueueTensorAllocator(new MetricRegistry()), new KvBufferCacheSettings(true),
+                    new DefaultToolCallParser(), new WrappedForkJoinPool(new ForkJoinPool(1)), tensorParallelContext);
+            this.hotSwapSupported = hotSwapSupported;
+        }
+
+        @Override
+        protected boolean supportsLoraHotSwap() {
+            return hotSwapSupported;
+        }
+
+        @Override
+        protected EmbedInput loadInputWeights() {
+            return null;
+        }
+
+        @Override
+        protected SampleOutput loadOutputWeights() {
+            return null;
+        }
+
+        @Override
+        protected TransformerBlock[] loadTransformerBlockWeights() {
+            return new TransformerBlock[0];
+        }
+    }
+
+    private static final class TinyWeightLoader implements WeightLoader {
+        private boolean closed;
+
+        @Override
+        public Map<String, String> metadata() {
+            return Map.of();
+        }
+
+        @Override
+        public Map<String, TensorInfo> tensorInfoMap() {
+            return Map.of();
+        }
+
+        @Override
+        public DType getModelDType() {
+            return DType.F32;
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+    }
+}

--- a/safetensors/src/main/java/io/teknek/deliverance/safetensors/LoraLayerDelta.java
+++ b/safetensors/src/main/java/io/teknek/deliverance/safetensors/LoraLayerDelta.java
@@ -1,0 +1,16 @@
+package io.teknek.deliverance.safetensors;
+
+import io.teknek.deliverance.tensor.AbstractTensor;
+
+/**
+ * One resolved, already-dtype-converted, already-scale-pre-multiplied LoRA delta for a single
+ * base tensor (e.g. one layer's {@code q_proj.weight}), ready to feed directly into the two
+ * matmuls that compute {@code scale * ((x @ loraA^T) @ loraB^T)} with no further per-call
+ * conversion work -- see step 4 plan Section 1 item 2.
+ *
+ * <p>{@code loraA} has shape {@code [rank, inFeatures]}; {@code scaledLoraB} has shape
+ * {@code [outFeatures, rank]} and already has the adapter's {@code alpha/r} scale baked in, so
+ * applying this delta never needs a separate {@code TensorOperations#scale} call.</p>
+ */
+public record LoraLayerDelta(AbstractTensor loraA, AbstractTensor scaledLoraB, int rank) {
+}

--- a/safetensors/src/main/java/io/teknek/deliverance/safetensors/LoraTensorMath.java
+++ b/safetensors/src/main/java/io/teknek/deliverance/safetensors/LoraTensorMath.java
@@ -1,0 +1,51 @@
+package io.teknek.deliverance.safetensors;
+
+import io.teknek.deliverance.DType;
+import io.teknek.deliverance.tensor.AbstractTensor;
+import io.teknek.deliverance.tensor.TensorShape;
+import io.teknek.deliverance.tensor.impl.BFloat16BufferTensor;
+import io.teknek.deliverance.tensor.impl.Float16BufferTensor;
+import io.teknek.deliverance.tensor.impl.FloatBufferTensor;
+
+/**
+ * Dtype-conversion helpers shared by {@link MergingWeightLoader} (Phase 1, merge-at-load) and
+ * {@link ResolvedLoraAdapter} (Phase 2, runtime hot-swap) for converting a {@code LoraAdapter}'s
+ * stored-dtype {@code loraA}/{@code loraB} tensors to whatever dtype the caller needs to combine
+ * them with.
+ *
+ * <p>Extracted from {@code MergingWeightLoader}'s originally-private helpers of the same shape --
+ * see step 3 plan Section 11 for why that PR kept them private, and step 4 plan Section 2 for why
+ * this PR (the second real caller) is the point to extract.</p>
+ */
+final class LoraTensorMath {
+
+    private LoraTensorMath() {
+    }
+
+    static AbstractTensor toDType(AbstractTensor src, DType target) {
+        if (src.dType() == target) {
+            return src;
+        }
+        return scaledCopy(src, target, 1.0f);
+    }
+
+    static AbstractTensor scaledCopy(AbstractTensor src, DType target, float factor) {
+        AbstractTensor converted = allocateLike(target, src.shape().first(), src.shape().last());
+        for (int row = 0; row < src.shape().first(); row++) {
+            for (int col = 0; col < src.shape().last(); col++) {
+                converted.set(src.get(row, col) * factor, row, col);
+            }
+        }
+        return converted;
+    }
+
+    static AbstractTensor allocateLike(DType dType, int rows, int cols) {
+        TensorShape shape = TensorShape.of(rows, cols);
+        return switch (dType) {
+            case F32 -> new FloatBufferTensor(shape);
+            case BF16 -> new BFloat16BufferTensor(shape);
+            case F16 -> new Float16BufferTensor(shape);
+            default -> throw new UnsupportedOperationException("Unsupported dtype for LoRA tensor math: " + dType);
+        };
+    }
+}

--- a/safetensors/src/main/java/io/teknek/deliverance/safetensors/MergingWeightLoader.java
+++ b/safetensors/src/main/java/io/teknek/deliverance/safetensors/MergingWeightLoader.java
@@ -4,10 +4,6 @@ import com.google.common.primitives.Ints;
 import io.teknek.deliverance.DType;
 import io.teknek.deliverance.tensor.AbstractTensor;
 import io.teknek.deliverance.tensor.TensorInfo;
-import io.teknek.deliverance.tensor.TensorShape;
-import io.teknek.deliverance.tensor.impl.BFloat16BufferTensor;
-import io.teknek.deliverance.tensor.impl.Float16BufferTensor;
-import io.teknek.deliverance.tensor.impl.FloatBufferTensor;
 import io.teknek.deliverance.tensor.operations.TensorOperations;
 
 import java.util.Map;
@@ -123,11 +119,11 @@ public class MergingWeightLoader implements WeightLoader {
         int inFeatures = base.shape().last();
         int rank = delta.loraA().shape().first();
 
-        AbstractTensor merged = allocateLike(base.dType(), outFeatures, inFeatures);
+        AbstractTensor merged = LoraTensorMath.allocateLike(base.dType(), outFeatures, inFeatures);
         merged.copyFrom(base, 0, 0, Ints.checkedCast(base.size()));
 
-        AbstractTensor loraA = toDType(delta.loraA(), base.dType());
-        AbstractTensor scaledB = scaledCopy(delta.loraB(), base.dType(), (float) adapter.scale());
+        AbstractTensor loraA = LoraTensorMath.toDType(delta.loraA(), base.dType());
+        AbstractTensor scaledB = LoraTensorMath.scaledCopy(delta.loraB(), base.dType(), (float) adapter.scale());
 
         for (int o = 0; o < outFeatures; o++) {
             AbstractTensor mergedRow = merged.slice(o);
@@ -135,37 +131,5 @@ public class MergingWeightLoader implements WeightLoader {
             tensorOps.saxpy(scaledBRow, loraA, mergedRow, 0, 0, inFeatures, 0, 0, rank);
         }
         return merged;
-    }
-
-    private static AbstractTensor toDType(AbstractTensor src, DType target) {
-        if (src.dType() == target) {
-            return src;
-        }
-        return scaledCopy(src, target, 1.0f);
-    }
-
-    private static AbstractTensor scaledCopy(AbstractTensor src, DType target, float factor) {
-        AbstractTensor converted = allocateLike(target, src.shape().first(), src.shape().last());
-        for (int row = 0; row < src.shape().first(); row++) {
-            for (int col = 0; col < src.shape().last(); col++) {
-                converted.set(src.get(row, col) * factor, row, col);
-            }
-        }
-        return converted;
-    }
-
-    /**
-     * Duplicated from {@link DefaultWeightLoader}'s private {@code allocateLike} rather than
-     * extracted into a shared utility -- see Section 11 of the step 3 plan for why this PR keeps
-     * the two copies independent.
-     */
-    private static AbstractTensor allocateLike(DType dType, int rows, int cols) {
-        TensorShape shape = TensorShape.of(rows, cols);
-        return switch (dType) {
-            case F32 -> new FloatBufferTensor(shape);
-            case BF16 -> new BFloat16BufferTensor(shape);
-            case F16 -> new Float16BufferTensor(shape);
-            default -> throw new UnsupportedOperationException("Unsupported dtype for LoRA merge: " + dType);
-        };
     }
 }

--- a/safetensors/src/main/java/io/teknek/deliverance/safetensors/ResolvedLoraAdapter.java
+++ b/safetensors/src/main/java/io/teknek/deliverance/safetensors/ResolvedLoraAdapter.java
@@ -1,0 +1,45 @@
+package io.teknek.deliverance.safetensors;
+
+import io.teknek.deliverance.DType;
+import io.teknek.deliverance.tensor.AbstractTensor;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Wraps a {@link LoraAdapter} for Phase 2 ("runtime hot-swap") use, lazily resolving and caching
+ * one {@link LoraLayerDelta} per base tensor name.
+ *
+ * <p>{@link LoraAdapter#deltaFor(String)} does real work on every call (a module-suffix parse, a
+ * set lookup, and -- if targeted -- two fresh {@code weights.load(...)} calls). Phase 1
+ * (merge-at-load) only ever pays this once per tensor, at load time; this class gives Phase 2 the
+ * same "pay once" property across every later token/request for a registered adapter, by caching
+ * the resolved, dtype-converted, pre-scaled result (including the {@code Optional.empty()} case
+ * for non-targeted names) behind a {@link ConcurrentHashMap}. See step 4 plan Section 3.2.</p>
+ */
+public class ResolvedLoraAdapter implements AutoCloseable {
+
+    private final LoraAdapter adapter;
+    private final DType targetDType;
+    private final ConcurrentHashMap<String, Optional<LoraLayerDelta>> cache = new ConcurrentHashMap<>();
+
+    public ResolvedLoraAdapter(LoraAdapter adapter, DType targetDType) {
+        this.adapter = adapter;
+        this.targetDType = targetDType;
+    }
+
+    public Optional<LoraLayerDelta> deltaFor(String baseTensorName) {
+        return cache.computeIfAbsent(baseTensorName, name -> adapter.deltaFor(name).map(this::resolve));
+    }
+
+    private LoraLayerDelta resolve(LoraAdapter.LoraDelta delta) {
+        AbstractTensor loraA = LoraTensorMath.toDType(delta.loraA(), targetDType);
+        AbstractTensor scaledLoraB = LoraTensorMath.scaledCopy(delta.loraB(), targetDType, (float) adapter.scale());
+        return new LoraLayerDelta(loraA, scaledLoraB, delta.loraA().shape().first());
+    }
+
+    @Override
+    public void close() {
+        adapter.close();
+    }
+}

--- a/safetensors/src/test/java/io/teknek/deliverance/safetensors/ResolvedLoraAdapterTest.java
+++ b/safetensors/src/test/java/io/teknek/deliverance/safetensors/ResolvedLoraAdapterTest.java
@@ -1,0 +1,110 @@
+package io.teknek.deliverance.safetensors;
+
+import io.teknek.deliverance.DType;
+import io.teknek.deliverance.tensor.AbstractTensor;
+import io.teknek.deliverance.tensor.impl.FloatBufferTensor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link ResolvedLoraAdapter} (Phase 2 runtime hot-swap), no network access --
+ * see step 4 plan Section 8. Uses the same synthetic-adapter-directory pattern as {@link
+ * LoraAdapterTest}.
+ */
+public class ResolvedLoraAdapterTest {
+
+    @TempDir
+    Path tempDir;
+
+    private static final String Q_PROJ = "model.layers.0.self_attn.q_proj.weight";
+    private static final String K_PROJ = "model.layers.0.self_attn.k_proj.weight";
+
+    @Test
+    void deltaForCachesTheResolvedDeltaAcrossCalls() throws IOException {
+        writeAdapterConfig(tempDir, 4, 8.0, "q_proj");
+        writeQProjTensors(tempDir, 4, 8, 6);
+
+        try (LoraAdapter adapter = LoraAdapter.load(tempDir.toFile());
+                ResolvedLoraAdapter resolved = new ResolvedLoraAdapter(adapter, DType.F32)) {
+            Optional<LoraLayerDelta> first = resolved.deltaFor(Q_PROJ);
+            Optional<LoraLayerDelta> second = resolved.deltaFor(Q_PROJ);
+
+            assertTrue(first.isPresent());
+            assertSame(first.get(), second.get(), "second call must return the cached instance, not re-resolve");
+        }
+    }
+
+    @Test
+    void scaledLoraBIsPreScaledByAdapterScale() throws IOException {
+        int rank = 4;
+        double alpha = 8.0; // scale = alpha / r = 2.0
+        writeAdapterConfig(tempDir, rank, alpha, "q_proj");
+
+        int inFeatures = 8;
+        int outFeatures = 6;
+        Map<String, AbstractTensor> tensors = new LinkedHashMap<>();
+        FloatBufferTensor loraB = new FloatBufferTensor(outFeatures, rank);
+        for (int row = 0; row < outFeatures; row++) {
+            for (int col = 0; col < rank; col++) {
+                loraB.set((row * rank + col) + 1.0f, row, col);
+            }
+        }
+        tensors.put(LoraTensorNames.loraA(Q_PROJ), new FloatBufferTensor(rank, inFeatures));
+        tensors.put(LoraTensorNames.loraB(Q_PROJ), loraB);
+        SafeTensorWriter.write(tempDir.resolve(LoraAdapter.SAFETENSORS_FILE_NAME), Map.of(), tensors);
+
+        try (LoraAdapter adapter = LoraAdapter.load(tempDir.toFile());
+                ResolvedLoraAdapter resolved = new ResolvedLoraAdapter(adapter, DType.F32)) {
+            LoraLayerDelta delta = resolved.deltaFor(Q_PROJ).orElseThrow();
+            assertEquals(rank, delta.rank());
+            for (int row = 0; row < outFeatures; row++) {
+                for (int col = 0; col < rank; col++) {
+                    float expected = ((row * rank + col) + 1.0f) * 2.0f;
+                    assertEquals(expected, delta.scaledLoraB().get(row, col), 1e-6f);
+                }
+            }
+        }
+    }
+
+    @Test
+    void nonTargetedNameCachesEmpty() throws IOException {
+        writeAdapterConfig(tempDir, 4, 8.0, "q_proj");
+        writeQProjTensors(tempDir, 4, 8, 6);
+
+        try (LoraAdapter adapter = LoraAdapter.load(tempDir.toFile());
+                ResolvedLoraAdapter resolved = new ResolvedLoraAdapter(adapter, DType.F32)) {
+            assertFalse(resolved.deltaFor(K_PROJ).isPresent());
+            assertFalse(resolved.deltaFor(K_PROJ).isPresent());
+        }
+    }
+
+    private static void writeQProjTensors(Path adapterDir, int rank, int inFeatures, int outFeatures) throws IOException {
+        Map<String, AbstractTensor> tensors = new LinkedHashMap<>();
+        tensors.put(LoraTensorNames.loraA(Q_PROJ), new FloatBufferTensor(rank, inFeatures));
+        tensors.put(LoraTensorNames.loraB(Q_PROJ), new FloatBufferTensor(outFeatures, rank));
+        SafeTensorWriter.write(adapterDir.resolve(LoraAdapter.SAFETENSORS_FILE_NAME), Map.of(), tensors);
+    }
+
+    private static void writeAdapterConfig(Path adapterDir, int rank, double alpha, String... targetModules)
+            throws IOException {
+        StringBuilder modules = new StringBuilder();
+        for (int i = 0; i < targetModules.length; i++) {
+            if (i > 0) modules.append(",");
+            modules.append("\"").append(targetModules[i]).append("\"");
+        }
+        String json = "{\"r\": " + rank + ", \"lora_alpha\": " + alpha + ", \"target_modules\": [" + modules + "]}";
+        Files.writeString(adapterDir.resolve(LoraAdapterConfig.FILE_NAME), json);
+    }
+}

--- a/web/src/main/java/net/deliverance/http/MultiModelProperties.java
+++ b/web/src/main/java/net/deliverance/http/MultiModelProperties.java
@@ -295,6 +295,31 @@ class TensorParallelSpringCausalLanguageModel implements CausalLanguageModel {
     }
 
     @Override
+    public void registerLoraAdapter(String adapterId, io.teknek.deliverance.safetensors.LoraAdapter adapter) {
+        coordinatorModel.registerLoraAdapter(adapterId, adapter);
+    }
+
+    @Override
+    public void registerLoraAdapter(String adapterId, io.teknek.deliverance.safetensors.fetch.LoraAdapterModelFetcher fetcher) {
+        coordinatorModel.registerLoraAdapter(adapterId, fetcher);
+    }
+
+    @Override
+    public void unregisterLoraAdapter(String adapterId) {
+        coordinatorModel.unregisterLoraAdapter(adapterId);
+    }
+
+    @Override
+    public void setActiveAdapter(String adapterId) {
+        coordinatorModel.setActiveAdapter(adapterId);
+    }
+
+    @Override
+    public void clearActiveAdapter() {
+        coordinatorModel.clearActiveAdapter();
+    }
+
+    @Override
     public void close() throws IOException {
         try {
             group.close();


### PR DESCRIPTION
## Summary

Phase 2 of LoRA support: runtime adapter hot-swap, on top of Phase 1's merge-at-load (`MergingWeightLoader`, #159). The base model stays resident and unmodified; adapter deltas are computed as a small extra matmul at the point of use in the forward pass (`x @ loraA^T @ loraB^T` added to the base projection's output), so adapters can be registered, activated, and cleared between requests with no base-weight touching or reloading. `AbstractModel` gains `registerLoraAdapter`/`unregisterLoraAdapter`/`setActiveAdapter`/`clearActiveAdapter`, mirrored on `CausalLanguageModel`. Opt-in per model family via `supportsLoraHotSwap()` (default `false`, matching `WeightLoader`'s own "must opt in by overriding" convention) — `LlamaModel`, `MistralModel`, `Gemma2Model`, `Gemma3Model`, `Qwen2Model`, `Qwen3Model` support it; MoE-routed families (`Qwen3MoeModel`, `GraniteMoeHybridModel`, `MixtralModel`) and `Gemma4Model` (independent forward-pass classes) do not, since a delta silently applied to only part of a targeted module would be a confusing, partial result.

Design and scope questions were raised with @edwardcapriolo ahead of implementation; his answers are folded into the design as shipped:
- Public API lives on `AbstractModel`/`CausalLanguageModel` as designed — he's separately interested in deprecating `AbstractModel` for being "too broad of an interface" long-term, but asked that this PR not design around that.
- `supportsLoraHotSwap()` stays opt-in-per-family (no preference either way from him, just "make it easy to use" — opt-in already serves that better here: a loud, immediate exception for an unsupported family beats a silently-partial adapter application).
- `AbstractModel.close()` now also closes the base `WeightLoader`, not just newly-registered adapters — a real, independently-confirmed pre-existing resource leak (mmap'd file handles were never released on model close, for *any* model, not just LoRA-enabled ones), fixed per his "if you can confirm [the leak] with close, fix it."

## Two real bugs found and fixed during implementation (in scope for this PR)

1. **LoRA input/weight dtype mismatch under quantization.** Every hook site's activation (`input`/`lnemb` for q/k/v/gate/up, `vq`/`bufq` for o_proj/down_proj) arrives already quantized to the model's working quant type before `LoraDeltaApplier` sees it — `TransformerBlock` quantizes the block's hidden state before calling attention/feed-forward, and each projection locally quantizes its own input before its base matmul. The SIMD/native matmul kernels only support a narrow set of `(activation dtype, weight dtype)` pairs (e.g. a `BF16` activation only pairs with `BF16`/`Q4`, never dense `F32`), so applying a dense-`F32`-resolved LoRA delta against that already-quantized activation threw `UnsupportedOperationException` at runtime the moment a real adapter was active under a non-dense-working-memory config (i.e. almost always). Fixed by having `LoraDeltaApplier` dequantize the activation to match the delta's dtype internally (an element-by-element copy, skipped entirely when the dtype already matches).
2. **Local prefix cache doesn't scope by active adapter.** `LocalGenerationBackend`'s prefix cache keys purely on `(promptTokens, callerSalt)`. Two requests sharing an identical prompt prefix (e.g. a common system prompt) but running under *different* active adapters — or one with no adapter active — would silently reuse KV state computed under the wrong adapter for the cached portion. This is a real correctness hazard for the actual multi-persona use case this feature exists for (one shared base model, several swappable per-persona adapters), not just a test artifact — found via this PR's own integration test hitting exactly this scenario. Fixed by having `AbstractModel` track the active adapter's registered id (`activeLoraAdapterId()`) and `LocalGenerationBackend` fold it into the effective cache salt before every prefix-cache lookup/store. No adapter active → caller's salt passes through unchanged, zero behavior change for models that never use hot-swap.

## Three pre-existing, unrelated issues found incidentally (out of scope, not fixed here)

Flagging these separately since they were found while testing this PR but have nothing to do with LoRA — confirmed via `git stash -u` / standalone no-LoRA reproductions against unmodified `main`:

1. `CausalSelfAttentionTensorParallelTest` (x3) and `MLPBlockTensorParallelTest` (x1) currently fail with NPEs: they mock `AbstractModel` but never stub `prefillProjectionOperations`, which the `Tensor runtime policy`/fusion-rewrite commits (#162-168) added as a required call on the forward path.
2. The `web` module doesn't compile: the openapi-generated `ApiClient.java` references `org.glassfish.jersey.media.multipart`/`org.glassfish.jersey.logging` classes that aren't on the classpath.
3. `PanamaTensorOperations.quantize` throws `UnsupportedOperationException: F32 => F32` from inside `MLPBlock`'s fused `TensorPlan` activation-multiply-quantize path whenever `.withWorkingQuantType(DType.F32)` is set against a real model — `quantize()` never handles the identity (source-already-target) case. This blocks this PR's own `phase1MergeAtLoadAndPhase2HotSwapAgreeUnderDenseWorkingMemory` test (which needs dense F32 working memory to be a meaningful comparison, per the note below) — confirmed unrelated to LoRA via a plain `generate()` call with zero adapter code involved. The test is written and correct; it will pass once this is fixed independently.

## Testing

- `ResolvedLoraAdapterTest`, `LoraDeltaApplierTest` — unit, no network, naive-reference math checks (same convention steps 1-3 used).
- `AbstractModelLoraHotSwapTest` — unit, no network, minimal real `AbstractModel` subclass (mocking doesn't work here since `registerLoraAdapter`/`setActiveAdapter` read real instance fields). Covers the non-goal guards (unsupported family, tensor-parallel, unregister-while-active) and the `close()` resource fix.
- `LoraHotSwapIntegrationTest#activatingAppliesTheAdapterAndClearingRestoresBaseModelBehavior` — real `unsloth/Llama-3.2-1B-Instruct` + `bunnycore/Llama-3.2-1b-chatml-lora_model` (same pairing as #159's own integration test). Passes.
- `LoraHotSwapIntegrationTest#phase1MergeAtLoadAndPhase2HotSwapAgreeUnderDenseWorkingMemory` — written, correct, currently blocked by pre-existing issue #3 above (not this PR's bug). Only expected to hold under dense (F32) working memory in the first place — Phase 1 computes `quantize(base + delta)` at load time, Phase 2 computes `quantize(base)` once and adds a separately-computed delta to the activation afterward; these are different operations under quantization, not just different implementations of the same one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)